### PR TITLE
Add files via upload

### DIFF
--- a/input/FieldEncountTable_d.json
+++ b/input/FieldEncountTable_d.json
@@ -157,8 +157,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 904
                 }
             ],
@@ -174,8 +174,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 904
                 }
             ],
@@ -191,8 +191,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 904
                 }
             ],
@@ -208,8 +208,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 904
                 }
             ],
@@ -225,8 +225,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 45,
                     "monsNo": 904
                 }
             ],
@@ -490,8 +490,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -507,8 +507,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -524,8 +524,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -541,8 +541,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -558,8 +558,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -823,8 +823,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -840,8 +840,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -857,8 +857,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -874,8 +874,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -891,8 +891,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -1156,8 +1156,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -1173,8 +1173,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -1190,8 +1190,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -1207,8 +1207,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -1224,8 +1224,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -1489,8 +1489,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 65735
                 }
             ],
@@ -1506,8 +1506,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 65735
                 }
             ],
@@ -1523,8 +1523,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 65735
                 }
             ],
@@ -1540,8 +1540,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 65735
                 }
             ],
@@ -1557,8 +1557,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 65735
                 }
             ],
@@ -1780,17 +1780,17 @@
                 {
                     "maxlv": 10,
                     "minlv": 10,
-                    "monsNo": 293
+                    "monsNo": 41
                 },
                 {
                     "maxlv": 10,
                     "minlv": 10,
-                    "monsNo": 304
+                    "monsNo": 41
                 },
                 {
                     "maxlv": 10,
                     "minlv": 10,
-                    "monsNo": 95
+                    "monsNo": 41
                 },
                 {
                     "maxlv": 10,
@@ -1822,8 +1822,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 10,
-                    "minlv": 10,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -1839,8 +1839,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 10,
-                    "minlv": 10,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -1856,8 +1856,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 10,
-                    "minlv": 10,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -1873,8 +1873,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 10,
-                    "minlv": 10,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -1890,8 +1890,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 10,
-                    "minlv": 10,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -2113,17 +2113,17 @@
                 {
                     "maxlv": 11,
                     "minlv": 11,
-                    "monsNo": 293
+                    "monsNo": 74
                 },
                 {
                     "maxlv": 11,
                     "minlv": 11,
-                    "monsNo": 304
+                    "monsNo": 74
                 },
                 {
                     "maxlv": 11,
                     "minlv": 11,
-                    "monsNo": 95
+                    "monsNo": 74
                 },
                 {
                     "maxlv": 11,
@@ -2155,8 +2155,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 11,
-                    "minlv": 11,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -2172,8 +2172,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 11,
-                    "minlv": 11,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -2189,8 +2189,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 11,
-                    "minlv": 11,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -2206,8 +2206,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 11,
-                    "minlv": 11,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -2223,8 +2223,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 11,
-                    "minlv": 11,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -2451,7 +2451,7 @@
                 {
                     "maxlv": 13,
                     "minlv": 13,
-                    "monsNo": 312
+                    "monsNo": 311
                 },
                 {
                     "maxlv": 13,
@@ -2461,7 +2461,7 @@
                 {
                     "maxlv": 13,
                     "minlv": 13,
-                    "monsNo": 312
+                    "monsNo": 311
                 }
             ],
             "FormProb": [
@@ -2488,8 +2488,8 @@
                     "monsNo": 65636
                 },
                 {
-                    "maxlv": 13,
-                    "minlv": 13,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -2505,8 +2505,8 @@
                     "monsNo": 65636
                 },
                 {
-                    "maxlv": 13,
-                    "minlv": 13,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -2522,8 +2522,8 @@
                     "monsNo": 65636
                 },
                 {
-                    "maxlv": 13,
-                    "minlv": 13,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -2539,8 +2539,8 @@
                     "monsNo": 65636
                 },
                 {
-                    "maxlv": 13,
-                    "minlv": 13,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -2556,8 +2556,8 @@
                     "monsNo": 65636
                 },
                 {
-                    "maxlv": 13,
-                    "minlv": 13,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -2779,22 +2779,22 @@
                 {
                     "maxlv": 16,
                     "minlv": 16,
-                    "monsNo": 267
+                    "monsNo": 265
                 },
                 {
                     "maxlv": 16,
                     "minlv": 16,
-                    "monsNo": 269
+                    "monsNo": 265
                 },
                 {
                     "maxlv": 16,
                     "minlv": 16,
-                    "monsNo": 267
+                    "monsNo": 265
                 },
                 {
                     "maxlv": 16,
                     "minlv": 16,
-                    "monsNo": 269
+                    "monsNo": 265
                 }
             ],
             "FormProb": [
@@ -2821,8 +2821,8 @@
                     "monsNo": 234
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -2838,8 +2838,8 @@
                     "monsNo": 234
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -2855,8 +2855,8 @@
                     "monsNo": 234
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -2872,8 +2872,8 @@
                     "monsNo": 234
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -2889,8 +2889,8 @@
                     "monsNo": 234
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -3154,8 +3154,8 @@
                     "monsNo": 65625
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
@@ -3171,8 +3171,8 @@
                     "monsNo": 65625
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
@@ -3188,8 +3188,8 @@
                     "monsNo": 65625
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
@@ -3205,8 +3205,8 @@
                     "monsNo": 65625
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
@@ -3223,7 +3223,7 @@
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 40,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
@@ -3387,12 +3387,12 @@
                 {
                     "maxlv": 23,
                     "minlv": 23,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 23,
                     "minlv": 23,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 23,
@@ -3445,17 +3445,17 @@
                 {
                     "maxlv": 23,
                     "minlv": 23,
-                    "monsNo": 358
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 23,
                     "minlv": 23,
-                    "monsNo": 42
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 23,
                     "minlv": 23,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 23,
@@ -3487,8 +3487,8 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -3504,8 +3504,8 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -3521,8 +3521,8 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -3538,8 +3538,8 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -3555,8 +3555,8 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -3778,17 +3778,17 @@
                 {
                     "maxlv": 51,
                     "minlv": 51,
-                    "monsNo": 358
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 51,
                     "minlv": 51,
-                    "monsNo": 42
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 51,
                     "minlv": 51,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 51,
@@ -3820,8 +3820,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -3837,8 +3837,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -3854,8 +3854,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -3871,8 +3871,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -3888,8 +3888,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -4111,17 +4111,17 @@
                 {
                     "maxlv": 51,
                     "minlv": 51,
-                    "monsNo": 358
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 51,
                     "minlv": 51,
-                    "monsNo": 42
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 51,
                     "minlv": 51,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 51,
@@ -4153,8 +4153,8 @@
                     "monsNo": 65563
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -4170,8 +4170,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -4187,8 +4187,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -4204,8 +4204,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -4221,8 +4221,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -4478,16 +4478,16 @@
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 66439
+                    "monsNo": 903
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 66439
+                    "monsNo": 903
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -4495,16 +4495,16 @@
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 66439
+                    "monsNo": 903
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 66439
+                    "monsNo": 903
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -4512,16 +4512,16 @@
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 66439
+                    "monsNo": 903
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 66439
+                    "monsNo": 903
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -4529,16 +4529,16 @@
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 66439
+                    "monsNo": 903
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 66439
+                    "monsNo": 903
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -4546,16 +4546,16 @@
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 66439
+                    "monsNo": 903
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 65679
+                    "monsNo": 903
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -4819,8 +4819,8 @@
                     "monsNo": 65574
                 },
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -4836,8 +4836,8 @@
                     "monsNo": 65574
                 },
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -4853,8 +4853,8 @@
                     "monsNo": 65574
                 },
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -4870,8 +4870,8 @@
                     "monsNo": 65574
                 },
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -4887,8 +4887,8 @@
                     "monsNo": 65574
                 },
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -5110,17 +5110,17 @@
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 358
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 42
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
@@ -5152,8 +5152,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 50,
+                    "minlv": 50,
                     "monsNo": 65735
                 }
             ],
@@ -5169,8 +5169,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 50,
+                    "minlv": 50,
                     "monsNo": 65735
                 }
             ],
@@ -5186,8 +5186,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 50,
+                    "minlv": 50,
                     "monsNo": 65735
                 }
             ],
@@ -5203,8 +5203,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 50,
+                    "minlv": 50,
                     "monsNo": 65735
                 }
             ],
@@ -5220,8 +5220,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 50,
+                    "minlv": 50,
                     "monsNo": 65735
                 }
             ],
@@ -5269,6 +5269,16 @@
                     "maxlv": 10,
                     "minlv": 10,
                     "monsNo": 147
+                },
+                {
+                    "maxlv": 10,
+                    "minlv": 10,
+                    "monsNo": 147
+                },
+                {
+                    "maxlv": 10,
+                    "minlv": 10,
+                    "monsNo": 147
                 }
             ],
             "encRate_turi_ii": 100,
@@ -5287,6 +5297,16 @@
                     "maxlv": 25,
                     "minlv": 25,
                     "monsNo": 147
+                },
+                {
+                    "maxlv": 25,
+                    "minlv": 25,
+                    "monsNo": 147
+                },
+                {
+                    "maxlv": 25,
+                    "minlv": 25,
+                    "monsNo": 147
                 }
             ],
             "encRate_sugoi": 100,
@@ -5300,6 +5320,16 @@
                     "maxlv": 50,
                     "minlv": 50,
                     "monsNo": 117
+                },
+                {
+                    "maxlv": 50,
+                    "minlv": 50,
+                    "monsNo": 148
+                },
+                {
+                    "maxlv": 50,
+                    "minlv": 50,
+                    "monsNo": 148
                 },
                 {
                     "maxlv": 50,
@@ -5413,17 +5443,17 @@
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 358
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 42
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
@@ -5455,8 +5485,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -5472,8 +5502,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -5489,8 +5519,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -5506,8 +5536,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -5523,8 +5553,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -5688,11 +5718,6 @@
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 337
-                },
-                {
-                    "maxlv": 53,
-                    "minlv": 53,
                     "monsNo": 338
                 },
                 {
@@ -5704,6 +5729,11 @@
                     "maxlv": 53,
                     "minlv": 53,
                     "monsNo": 338
+                },
+                {
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 337
                 }
             ],
             "tairyo": [
@@ -5746,17 +5776,17 @@
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 358
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 42
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
@@ -5788,8 +5818,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -5805,8 +5835,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -5822,8 +5852,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -5839,8 +5869,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -5856,8 +5886,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -5991,12 +6021,12 @@
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 299
+                    "monsNo": 35
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 35
+                    "monsNo": 299
                 },
                 {
                     "maxlv": 53,
@@ -6021,12 +6051,12 @@
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
@@ -6055,41 +6085,41 @@
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 299
+                    "monsNo": 35
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 35
+                    "monsNo": 299
                 }
             ],
             "night": [
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 299
+                    "monsNo": 35
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 35
+                    "monsNo": 299
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 358
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 42
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
@@ -6121,8 +6151,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -6138,8 +6168,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -6155,8 +6185,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -6172,8 +6202,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -6189,8 +6219,8 @@
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -6324,12 +6354,12 @@
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 299
+                    "monsNo": 35
                 },
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 35
+                    "monsNo": 299
                 },
                 {
                     "maxlv": 19,
@@ -6388,41 +6418,41 @@
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 299
+                    "monsNo": 35
                 },
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 35
+                    "monsNo": 299
                 }
             ],
             "night": [
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 299
+                    "monsNo": 35
                 },
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 35
+                    "monsNo": 299
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 374
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 41
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 19,
@@ -6454,8 +6484,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -6471,8 +6501,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -6488,8 +6518,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -6505,8 +6535,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -6522,8 +6552,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -6745,17 +6775,17 @@
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 374
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 41
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 19,
@@ -6787,8 +6817,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -6804,8 +6834,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -6821,8 +6851,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -6838,8 +6868,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -6855,8 +6885,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -7078,17 +7108,17 @@
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 433
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 41
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 18,
@@ -7120,8 +7150,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -7137,8 +7167,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -7154,8 +7184,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -7171,8 +7201,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -7188,8 +7218,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -7411,17 +7441,17 @@
                 {
                     "maxlv": 20,
                     "minlv": 20,
-                    "monsNo": 358
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 20,
                     "minlv": 20,
-                    "monsNo": 375
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 20,
                     "minlv": 20,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 20,
@@ -7453,9 +7483,9 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
-                    "monsNo": 0
+                    "maxlv": 45,
+                    "minlv": 45,
+                    "monsNo": 65615
                 }
             ],
             "gbaSapp": [
@@ -7470,9 +7500,9 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
-                    "monsNo": 0
+                    "maxlv": 45,
+                    "minlv": 45,
+                    "monsNo": 65615
                 }
             ],
             "gbaEme": [
@@ -7487,9 +7517,9 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
-                    "monsNo": 0
+                    "maxlv": 45,
+                    "minlv": 45,
+                    "monsNo": 65615
                 }
             ],
             "gbaFire": [
@@ -7504,9 +7534,9 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
-                    "monsNo": 0
+                    "maxlv": 45,
+                    "minlv": 45,
+                    "monsNo": 65615
                 }
             ],
             "gbaLeaf": [
@@ -7521,9 +7551,9 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
-                    "monsNo": 0
+                    "maxlv": 45,
+                    "minlv": 45,
+                    "monsNo": 65615
                 }
             ],
             "encRate_wat": 10,
@@ -7656,12 +7686,12 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 114
+                    "monsNo": 357
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 357
+                    "monsNo": 114
                 },
                 {
                     "maxlv": 36,
@@ -7708,48 +7738,48 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 357
+                    "monsNo": 400
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 114
+                    "monsNo": 195
                 }
             ],
             "day": [
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 114
+                    "monsNo": 357
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 357
+                    "monsNo": 114
                 }
             ],
             "night": [
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 114
+                    "monsNo": 357
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 357
+                    "monsNo": 114
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 455
+                    "monsNo": 400
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 357
+                    "monsNo": 400
                 },
                 {
                     "maxlv": 36,
@@ -7786,8 +7816,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -7803,8 +7833,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -7820,8 +7850,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -7837,8 +7867,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -7854,8 +7884,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -8041,12 +8071,12 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 357
+                    "monsNo": 400
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 114
+                    "monsNo": 195
                 }
             ],
             "day": [
@@ -8077,12 +8107,12 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 455
+                    "monsNo": 400
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 357
+                    "monsNo": 400
                 },
                 {
                     "maxlv": 36,
@@ -8119,8 +8149,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -8136,8 +8166,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -8153,8 +8183,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -8170,8 +8200,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -8187,8 +8217,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -8332,7 +8362,7 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 183
+                    "monsNo": 47
                 },
                 {
                     "maxlv": 36,
@@ -8374,12 +8404,12 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 453
+                    "monsNo": 47
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 454
+                    "monsNo": 102
                 }
             ],
             "day": [
@@ -8410,22 +8440,22 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 47
+                    "monsNo": 193
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 453
+                    "monsNo": 193
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 115
+                    "monsNo": 193
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 469
+                    "monsNo": 193
                 }
             ],
             "FormProb": [
@@ -8452,8 +8482,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -8469,8 +8499,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -8486,8 +8516,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -8503,8 +8533,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -8520,8 +8550,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -8707,12 +8737,12 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 453
+                    "monsNo": 47
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 454
+                    "monsNo": 102
                 }
             ],
             "day": [
@@ -8743,17 +8773,17 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 47
+                    "monsNo": 193
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 453
+                    "monsNo": 193
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 115
+                    "monsNo": 193
                 },
                 {
                     "maxlv": 36,
@@ -8785,8 +8815,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -8802,8 +8832,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -8819,8 +8849,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -8836,8 +8866,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -8853,8 +8883,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -8988,12 +9018,17 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 451
+                    "monsNo": 285
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
                     "monsNo": 285
+                },
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 451
                 },
                 {
                     "maxlv": 36,
@@ -9003,11 +9038,6 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 285
-                },
-                {
-                    "maxlv": 36,
-                    "minlv": 36,
                     "monsNo": 317
                 },
                 {
@@ -9028,7 +9058,7 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 217
+                    "monsNo": 317
                 },
                 {
                     "maxlv": 36,
@@ -9045,14 +9075,14 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 285
+                    "monsNo": 316
                 }
             ],
             "day": [
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 451
+                    "monsNo": 285
                 },
                 {
                     "maxlv": 36,
@@ -9064,7 +9094,7 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 451
+                    "monsNo": 285
                 },
                 {
                     "maxlv": 36,
@@ -9076,17 +9106,17 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 452
+                    "monsNo": 286
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 285
+                    "monsNo": 286
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 317
+                    "monsNo": 286
                 },
                 {
                     "maxlv": 36,
@@ -9118,8 +9148,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -9135,8 +9165,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -9152,8 +9182,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -9169,8 +9199,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -9186,8 +9216,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -9321,12 +9351,17 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 451
+                    "monsNo": 285
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
                     "monsNo": 285
+                },
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 451
                 },
                 {
                     "maxlv": 36,
@@ -9336,11 +9371,6 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 285
-                },
-                {
-                    "maxlv": 36,
-                    "minlv": 36,
                     "monsNo": 317
                 },
                 {
@@ -9361,7 +9391,7 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 217
+                    "monsNo": 317
                 },
                 {
                     "maxlv": 36,
@@ -9378,14 +9408,14 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 285
+                    "monsNo": 316
                 }
             ],
             "day": [
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 451
+                    "monsNo": 285
                 },
                 {
                     "maxlv": 36,
@@ -9397,7 +9427,7 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 451
+                    "monsNo": 285
                 },
                 {
                     "maxlv": 36,
@@ -9409,17 +9439,17 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 452
+                    "monsNo": 286
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 285
+                    "monsNo": 286
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 317
+                    "monsNo": 286
                 },
                 {
                     "maxlv": 36,
@@ -9451,8 +9481,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -9468,8 +9498,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -9485,8 +9515,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -9502,8 +9532,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -9519,8 +9549,8 @@
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -9784,8 +9814,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -9801,8 +9831,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -9818,8 +9848,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -9835,8 +9865,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -9852,8 +9882,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -10117,8 +10147,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -10134,8 +10164,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -10151,8 +10181,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -10168,8 +10198,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -10185,8 +10215,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -10450,8 +10480,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -10467,8 +10497,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -10484,8 +10514,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -10501,8 +10531,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -10518,8 +10548,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -10783,8 +10813,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -10800,8 +10830,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -10817,8 +10847,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -10834,8 +10864,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -10851,8 +10881,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -11116,8 +11146,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -11133,8 +11163,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -11150,8 +11180,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -11167,8 +11197,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -11184,8 +11214,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -11449,8 +11479,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -11466,8 +11496,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -11483,8 +11513,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -11500,8 +11530,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -11517,8 +11547,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -11782,8 +11812,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -11799,8 +11829,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -11816,8 +11846,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -11833,8 +11863,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -11850,8 +11880,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -12115,8 +12145,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -12132,8 +12162,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -12149,8 +12179,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -12166,8 +12196,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -12183,8 +12213,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -12448,8 +12478,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -12465,8 +12495,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -12482,8 +12512,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -12499,8 +12529,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -12516,8 +12546,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -12781,8 +12811,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -12798,8 +12828,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -12815,8 +12845,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -12832,8 +12862,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -12849,8 +12879,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -13114,8 +13144,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -13131,8 +13161,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -13148,8 +13178,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -13165,8 +13195,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -13182,8 +13212,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -13447,8 +13477,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -13464,8 +13494,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -13481,8 +13511,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -13498,8 +13528,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -13515,8 +13545,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -13780,8 +13810,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -13797,8 +13827,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -13814,8 +13844,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -13831,8 +13861,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -13848,8 +13878,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -14113,8 +14143,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -14130,8 +14160,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -14147,8 +14177,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -14164,8 +14194,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -14181,8 +14211,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -14446,8 +14476,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -14463,8 +14493,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -14480,8 +14510,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -14497,8 +14527,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -14514,8 +14544,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -14779,8 +14809,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -14796,8 +14826,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -14813,8 +14843,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -14830,8 +14860,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -14847,8 +14877,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -15112,8 +15142,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -15129,8 +15159,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -15146,8 +15176,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -15163,8 +15193,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -15180,8 +15210,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -15445,8 +15475,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -15462,8 +15492,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -15479,8 +15509,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -15496,8 +15526,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -15513,8 +15543,8 @@
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -15736,17 +15766,17 @@
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 297
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 444
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 112
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 59,
@@ -15778,8 +15808,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -15795,8 +15825,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -15812,8 +15842,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -15829,8 +15859,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -15846,8 +15876,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -16069,17 +16099,17 @@
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 108
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 42
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 105
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
@@ -16111,8 +16141,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -16128,8 +16158,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -16145,8 +16175,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -16162,8 +16192,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -16179,8 +16209,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -16314,7 +16344,7 @@
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 76
+                    "monsNo": 75
                 },
                 {
                     "maxlv": 59,
@@ -16366,7 +16396,7 @@
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 76
+                    "monsNo": 75
                 },
                 {
                     "maxlv": 59,
@@ -16402,17 +16432,17 @@
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 302
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 87
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 42
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
@@ -16444,8 +16474,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16461,8 +16491,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16478,8 +16508,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16495,8 +16525,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16512,8 +16542,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 40,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16735,17 +16765,17 @@
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 308
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 87
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 42
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
@@ -16777,8 +16807,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16794,8 +16824,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16811,8 +16841,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16828,8 +16858,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16845,8 +16875,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 40,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -17068,17 +17098,17 @@
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 308
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 208
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 42
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
@@ -17110,8 +17140,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -17127,8 +17157,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -17144,8 +17174,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -17161,8 +17191,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -17178,8 +17208,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -17401,17 +17431,17 @@
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 308
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 208
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 42
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
@@ -17443,8 +17473,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -17460,8 +17490,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -17477,8 +17507,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -17494,8 +17524,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -17511,8 +17541,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -17734,7 +17764,7 @@
                 {
                     "maxlv": 8,
                     "minlv": 8,
-                    "monsNo": 41
+                    "monsNo": 74
                 },
                 {
                     "maxlv": 8,
@@ -17744,7 +17774,7 @@
                 {
                     "maxlv": 8,
                     "minlv": 8,
-                    "monsNo": 41
+                    "monsNo": 74
                 },
                 {
                     "maxlv": 8,
@@ -17776,8 +17806,8 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 8,
-                    "minlv": 8,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -17793,8 +17823,8 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 8,
-                    "minlv": 8,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -17810,8 +17840,8 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 8,
-                    "minlv": 8,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -17827,8 +17857,8 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 8,
-                    "minlv": 8,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -17844,8 +17874,8 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 8,
-                    "minlv": 8,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -18008,12 +18038,12 @@
                 },
                 {
                     "maxlv": 9,
-                    "minlv": 9,
+                    "minlv": 8,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 9,
-                    "minlv": 9,
+                    "minlv": 8,
                     "monsNo": 50
                 },
                 {
@@ -18067,12 +18097,12 @@
                 {
                     "maxlv": 9,
                     "minlv": 9,
-                    "monsNo": 41
+                    "monsNo": 50
                 },
                 {
                     "maxlv": 9,
                     "minlv": 9,
-                    "monsNo": 74
+                    "monsNo": 50
                 },
                 {
                     "maxlv": 9,
@@ -18109,8 +18139,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 9,
-                    "minlv": 9,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -18126,8 +18156,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 9,
-                    "minlv": 9,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -18143,8 +18173,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 9,
-                    "minlv": 9,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -18160,8 +18190,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 9,
-                    "minlv": 9,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -18177,8 +18207,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 9,
-                    "minlv": 9,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -18400,12 +18430,12 @@
                 {
                     "maxlv": 10,
                     "minlv": 10,
-                    "monsNo": 41
+                    "monsNo": 50
                 },
                 {
                     "maxlv": 10,
                     "minlv": 10,
-                    "monsNo": 74
+                    "monsNo": 50
                 },
                 {
                     "maxlv": 10,
@@ -18442,8 +18472,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 10,
-                    "minlv": 10,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -18459,8 +18489,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 10,
-                    "minlv": 10,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -18476,8 +18506,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 10,
-                    "minlv": 10,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -18493,8 +18523,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 10,
-                    "minlv": 10,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -18510,8 +18540,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 10,
-                    "minlv": 10,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -18733,17 +18763,17 @@
                 {
                     "maxlv": 69,
                     "minlv": 69,
-                    "monsNo": 227
+                    "monsNo": 324
                 },
                 {
                     "maxlv": 69,
                     "minlv": 69,
-                    "monsNo": 207
+                    "monsNo": 324
                 },
                 {
                     "maxlv": 69,
                     "minlv": 69,
-                    "monsNo": 323
+                    "monsNo": 324
                 },
                 {
                     "maxlv": 69,
@@ -18765,86 +18795,86 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 68,
+                    "minlv": 68,
                     "monsNo": 65641
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 68,
+                    "minlv": 68,
                     "monsNo": 65641
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 68,
+                    "minlv": 68,
                     "monsNo": 65641
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 68,
+                    "minlv": 68,
                     "monsNo": 65641
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
             "gbaEme": [
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 68,
+                    "minlv": 68,
                     "monsNo": 65641
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 68,
+                    "minlv": 68,
                     "monsNo": 65641
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
             "gbaFire": [
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 68,
+                    "minlv": 68,
                     "monsNo": 65641
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 68,
+                    "minlv": 68,
                     "monsNo": 65641
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 68,
+                    "minlv": 68,
                     "monsNo": 65641
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 68,
+                    "minlv": 68,
                     "monsNo": 65641
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -19066,17 +19096,17 @@
                 {
                     "maxlv": 69,
                     "minlv": 69,
-                    "monsNo": 67
+                    "monsNo": 89
                 },
                 {
                     "maxlv": 69,
                     "minlv": 69,
-                    "monsNo": 324
+                    "monsNo": 89
                 },
                 {
                     "maxlv": 69,
                     "minlv": 69,
-                    "monsNo": 110
+                    "monsNo": 89
                 },
                 {
                     "maxlv": 69,
@@ -19108,8 +19138,8 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -19125,8 +19155,8 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -19142,8 +19172,8 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -19159,8 +19189,8 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -19176,8 +19206,8 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -19399,17 +19429,17 @@
                 {
                     "maxlv": 69,
                     "minlv": 69,
-                    "monsNo": 67
+                    "monsNo": 89
                 },
                 {
                     "maxlv": 69,
                     "minlv": 69,
-                    "monsNo": 324
+                    "monsNo": 89
                 },
                 {
                     "maxlv": 69,
                     "minlv": 69,
-                    "monsNo": 110
+                    "monsNo": 89
                 },
                 {
                     "maxlv": 69,
@@ -19441,8 +19471,8 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -19458,8 +19488,8 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -19475,8 +19505,8 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -19492,8 +19522,8 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -19509,8 +19539,8 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 69,
-                    "minlv": 69,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -19774,8 +19804,8 @@
                     "monsNo": 864
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 65735
                 }
             ],
@@ -19791,8 +19821,8 @@
                     "monsNo": 864
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 65735
                 }
             ],
@@ -19808,8 +19838,8 @@
                     "monsNo": 864
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 65735
                 }
             ],
@@ -19825,8 +19855,8 @@
                     "monsNo": 864
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 65735
                 }
             ],
@@ -19843,7 +19873,7 @@
                 },
                 {
                     "maxlv": 54,
-                    "minlv": 54,
+                    "minlv": 55,
                     "monsNo": 65735
                 }
             ],
@@ -20065,17 +20095,17 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 358
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
@@ -20107,8 +20137,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -20124,8 +20154,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -20141,8 +20171,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -20155,20 +20185,15 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 65694
+                    "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
             "gbaLeaf": [
-                {
-                    "maxlv": 66,
-                    "minlv": 66,
-                    "monsNo": 65694
-                },
                 {
                     "maxlv": 66,
                     "minlv": 66,
@@ -20177,6 +20202,11 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
+                    "monsNo": 65693
+                },
+                {
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -20398,17 +20428,17 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 358
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
@@ -20440,8 +20470,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -20457,8 +20487,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -20474,8 +20504,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -20491,8 +20521,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -20508,8 +20538,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -20731,22 +20761,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -20773,8 +20803,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -20790,8 +20820,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -20807,8 +20837,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -20824,8 +20854,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -20841,8 +20871,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -21064,22 +21094,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -21106,8 +21136,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -21123,8 +21153,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -21140,8 +21170,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -21157,8 +21187,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -21174,8 +21204,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -21397,22 +21427,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -21439,8 +21469,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -21456,8 +21486,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -21473,8 +21503,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -21490,8 +21520,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -21507,8 +21537,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -21730,22 +21760,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -21772,8 +21802,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -21789,8 +21819,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -21806,8 +21836,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -21823,8 +21853,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -21840,8 +21870,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -22063,22 +22093,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -22105,8 +22135,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -22122,8 +22152,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -22139,8 +22169,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -22156,8 +22186,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -22173,8 +22203,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -22396,22 +22426,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -22438,8 +22468,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -22455,8 +22485,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -22472,8 +22502,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -22489,8 +22519,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -22506,8 +22536,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -22641,12 +22671,12 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 354
+                    "monsNo": 356
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 356
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 66,
@@ -22693,12 +22723,12 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 354
+                    "monsNo": 356
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 356
+                    "monsNo": 354
                 }
             ],
             "day": [
@@ -22729,22 +22759,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -22771,8 +22801,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -22788,8 +22818,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -22805,8 +22835,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -22822,8 +22852,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -22839,8 +22869,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -23062,22 +23092,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -23104,8 +23134,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -23121,8 +23151,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -23138,8 +23168,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -23155,8 +23185,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -23172,8 +23202,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -23395,22 +23425,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -23437,8 +23467,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -23454,8 +23484,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -23471,8 +23501,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -23488,8 +23518,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -23505,8 +23535,8 @@
                     "monsNo": 157
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -23728,22 +23758,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -23770,8 +23800,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -23787,8 +23817,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -23804,8 +23834,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -23821,8 +23851,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -23838,8 +23868,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -24061,22 +24091,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -24103,8 +24133,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -24120,8 +24150,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -24137,8 +24167,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -24154,8 +24184,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -24171,8 +24201,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -24394,22 +24424,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -24436,8 +24466,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -24453,8 +24483,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -24470,8 +24500,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -24487,8 +24517,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -24504,8 +24534,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -24727,22 +24757,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -24769,8 +24799,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -24786,8 +24816,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -24803,8 +24833,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -24820,8 +24850,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -24837,8 +24867,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -25060,22 +25090,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -25102,8 +25132,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -25119,8 +25149,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -25136,8 +25166,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -25153,8 +25183,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -25170,8 +25200,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -25393,22 +25423,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -25435,8 +25465,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -25452,8 +25482,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -25469,8 +25499,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -25486,8 +25516,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -25503,8 +25533,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -25726,22 +25756,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -25768,8 +25798,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -25785,8 +25815,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -25802,8 +25832,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -25819,8 +25849,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -25836,8 +25866,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -26059,22 +26089,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -26101,8 +26131,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -26118,8 +26148,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -26135,8 +26165,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -26152,8 +26182,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -26169,8 +26199,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -26392,22 +26422,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -26434,8 +26464,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -26451,8 +26481,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -26468,8 +26498,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -26485,8 +26515,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -26502,8 +26532,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -26725,22 +26755,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -26756,23 +26786,6 @@
                 0
             ],
             "gbaRuby": [
-                {
-                    "maxlv": 66,
-                    "minlv": 66,
-                    "monsNo": 65693
-                },
-                {
-                    "maxlv": 66,
-                    "minlv": 66,
-                    "monsNo": 65693
-                },
-                {
-                    "maxlv": 66,
-                    "minlv": 66,
-                    "monsNo": 0
-                }
-            ],
-            "gbaSapp": [
                 {
                     "maxlv": 66,
                     "minlv": 66,
@@ -26784,8 +26797,25 @@
                     "monsNo": 65693
                 },
                 {
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
+                }
+            ],
+            "gbaSapp": [
+                {
                     "maxlv": 66,
                     "minlv": 66,
+                    "monsNo": 65693
+                },
+                {
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 65693
+                },
+                {
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -26801,8 +26831,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -26818,8 +26848,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -26835,8 +26865,8 @@
                     "monsNo": 65693
                 },
                 {
-                    "maxlv": 66,
-                    "minlv": 66,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -27058,7 +27088,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -27068,7 +27098,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -27092,7 +27122,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -27100,8 +27130,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -27114,11 +27144,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -27126,16 +27156,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -27143,16 +27173,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -27160,16 +27190,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -27391,7 +27421,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -27401,7 +27431,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -27425,7 +27455,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -27433,8 +27463,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -27447,11 +27477,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -27459,16 +27489,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -27476,16 +27506,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -27493,16 +27523,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -27724,7 +27754,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -27734,7 +27764,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -27758,7 +27788,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -27766,8 +27796,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -27780,11 +27810,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -27792,16 +27822,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -27809,16 +27839,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -27826,16 +27856,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -28057,7 +28087,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -28067,7 +28097,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -28091,7 +28121,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -28099,8 +28129,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -28113,11 +28143,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -28125,16 +28155,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -28142,16 +28172,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -28159,16 +28189,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -28390,7 +28420,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -28400,7 +28430,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -28424,7 +28454,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -28432,8 +28462,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -28446,11 +28476,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -28458,16 +28488,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -28475,16 +28505,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -28492,16 +28522,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -28723,7 +28753,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -28733,7 +28763,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -28757,7 +28787,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -28765,8 +28795,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -28779,11 +28809,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -28791,16 +28821,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -28808,16 +28838,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -28825,16 +28855,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -29056,7 +29086,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -29066,7 +29096,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -29090,7 +29120,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -29098,8 +29128,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -29112,11 +29142,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -29124,16 +29154,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -29141,16 +29171,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -29158,16 +29188,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -29389,7 +29419,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -29399,7 +29429,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -29423,7 +29453,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -29431,8 +29461,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -29445,11 +29475,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -29457,16 +29487,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -29474,16 +29504,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -29491,16 +29521,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -29722,7 +29752,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -29732,7 +29762,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -29756,7 +29786,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -29764,8 +29794,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -29778,11 +29808,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -29790,16 +29820,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -29807,16 +29837,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -29824,16 +29854,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -30055,7 +30085,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -30065,7 +30095,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -30089,7 +30119,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -30097,8 +30127,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -30111,11 +30141,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -30123,16 +30153,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -30140,16 +30170,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -30157,16 +30187,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -30388,7 +30418,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -30398,7 +30428,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -30422,7 +30452,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -30430,8 +30460,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -30444,11 +30474,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -30456,16 +30486,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -30473,16 +30503,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -30490,16 +30520,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -30721,7 +30751,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -30731,7 +30761,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -30755,7 +30785,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -30763,8 +30793,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -30777,11 +30807,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -30789,16 +30819,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -30806,16 +30836,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -30823,16 +30853,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -31054,7 +31084,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -31064,7 +31094,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -31088,7 +31118,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -31096,8 +31126,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -31110,11 +31140,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -31122,16 +31152,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -31139,16 +31169,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -31156,16 +31186,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -31387,7 +31417,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -31397,7 +31427,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -31421,7 +31451,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -31429,8 +31459,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -31443,11 +31473,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -31455,16 +31485,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -31472,16 +31502,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -31489,16 +31519,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -31720,7 +31750,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -31730,7 +31760,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -31754,7 +31784,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -31762,8 +31792,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -31776,11 +31806,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -31788,16 +31818,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -31805,16 +31835,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -31822,16 +31852,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -32053,7 +32083,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -32063,7 +32093,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -32087,7 +32117,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -32095,8 +32125,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -32109,11 +32139,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -32121,16 +32151,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -32138,16 +32168,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -32155,16 +32185,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -32386,7 +32416,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -32396,7 +32426,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -32420,7 +32450,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -32428,8 +32458,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -32442,11 +32472,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -32454,16 +32484,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -32471,16 +32501,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -32488,16 +32518,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -32719,7 +32749,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -32729,7 +32759,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -32753,7 +32783,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -32761,8 +32791,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -32775,11 +32805,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -32787,16 +32817,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -32804,16 +32834,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -32821,16 +32851,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -33052,7 +33082,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -33062,7 +33092,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -33086,7 +33116,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -33094,8 +33124,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -33108,11 +33138,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -33120,16 +33150,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -33137,16 +33167,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -33154,16 +33184,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -33385,7 +33415,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -33395,7 +33425,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -33419,7 +33449,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -33427,8 +33457,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -33441,11 +33471,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -33453,16 +33483,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -33470,16 +33500,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -33487,16 +33517,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -33718,7 +33748,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -33728,7 +33758,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -33752,7 +33782,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -33760,8 +33790,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -33774,11 +33804,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -33786,16 +33816,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -33803,16 +33833,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -33820,16 +33850,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -34051,7 +34081,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -34061,7 +34091,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -34085,7 +34115,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -34093,8 +34123,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -34107,11 +34137,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -34119,16 +34149,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -34136,16 +34166,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -34153,16 +34183,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -34384,7 +34414,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -34394,7 +34424,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -34418,7 +34448,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -34426,8 +34456,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -34440,11 +34470,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -34452,16 +34482,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -34469,16 +34499,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -34486,16 +34516,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -34717,7 +34747,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -34727,7 +34757,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -34751,7 +34781,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -34759,8 +34789,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -34773,11 +34803,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -34785,16 +34815,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -34802,16 +34832,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -34819,16 +34849,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -35050,7 +35080,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -35060,7 +35090,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -35084,7 +35114,7 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 338
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -35092,8 +35122,8 @@
                     "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -35106,11 +35136,11 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -35118,16 +35148,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -35135,16 +35165,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -35152,16 +35182,16 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 436
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -35383,17 +35413,17 @@
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 208
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 124
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 461
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
@@ -35425,8 +35455,8 @@
                     "monsNo": 65574
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -35442,8 +35472,8 @@
                     "monsNo": 65574
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -35459,8 +35489,8 @@
                     "monsNo": 65574
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -35476,8 +35506,8 @@
                     "monsNo": 65574
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -35493,8 +35523,8 @@
                     "monsNo": 65574
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -35716,17 +35746,17 @@
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 208
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 124
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 461
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
@@ -35758,8 +35788,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -35775,8 +35805,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -35792,8 +35822,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -35809,8 +35839,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -35826,8 +35856,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -36049,17 +36079,17 @@
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 208
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 124
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 461
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
@@ -36091,8 +36121,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -36108,8 +36138,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -36125,8 +36155,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -36142,8 +36172,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -36159,8 +36189,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -36382,17 +36412,17 @@
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 208
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 124
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 461
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
@@ -36424,8 +36454,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -36441,8 +36471,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -36458,8 +36488,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -36475,8 +36505,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -36492,8 +36522,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -36715,17 +36745,17 @@
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 208
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 124
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 461
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
@@ -36757,8 +36787,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -36774,8 +36804,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -36791,8 +36821,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -36808,8 +36838,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -36825,8 +36855,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -37048,17 +37078,17 @@
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 208
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 124
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 461
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
@@ -37090,8 +37120,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -37107,8 +37137,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -37124,8 +37154,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -37141,8 +37171,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -37158,8 +37188,8 @@
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -37381,12 +37411,12 @@
                 {
                     "maxlv": 22,
                     "minlv": 22,
-                    "monsNo": 27
+                    "monsNo": 443
                 },
                 {
                     "maxlv": 22,
                     "minlv": 22,
-                    "monsNo": 95
+                    "monsNo": 443
                 },
                 {
                     "maxlv": 22,
@@ -37423,8 +37453,8 @@
                     "monsNo": 443
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -37440,8 +37470,8 @@
                     "monsNo": 443
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -37457,8 +37487,8 @@
                     "monsNo": 443
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -37474,8 +37504,8 @@
                     "monsNo": 443
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -37491,8 +37521,8 @@
                     "monsNo": 443
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -37714,12 +37744,12 @@
                 {
                     "maxlv": 22,
                     "minlv": 22,
-                    "monsNo": 27
+                    "monsNo": 443
                 },
                 {
                     "maxlv": 22,
                     "minlv": 22,
-                    "monsNo": 95
+                    "monsNo": 443
                 },
                 {
                     "maxlv": 22,
@@ -37756,8 +37786,8 @@
                     "monsNo": 443
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -37773,8 +37803,8 @@
                     "monsNo": 443
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -37790,8 +37820,8 @@
                     "monsNo": 443
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -37807,8 +37837,8 @@
                     "monsNo": 443
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -37824,8 +37854,8 @@
                     "monsNo": 443
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -38047,17 +38077,17 @@
                 {
                     "maxlv": 32,
                     "minlv": 32,
-                    "monsNo": 294
+                    "monsNo": 51
                 },
                 {
                     "maxlv": 32,
                     "minlv": 32,
-                    "monsNo": 132
+                    "monsNo": 51
                 },
                 {
                     "maxlv": 32,
                     "minlv": 32,
-                    "monsNo": 328
+                    "monsNo": 51
                 },
                 {
                     "maxlv": 32,
@@ -38089,8 +38119,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -38106,8 +38136,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -38123,8 +38153,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -38140,8 +38170,8 @@
                     "monsNo": 65587
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -38157,8 +38187,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -38380,17 +38410,17 @@
                 {
                     "maxlv": 32,
                     "minlv": 32,
-                    "monsNo": 294
+                    "monsNo": 51
                 },
                 {
                     "maxlv": 32,
                     "minlv": 32,
-                    "monsNo": 132
+                    "monsNo": 51
                 },
                 {
                     "maxlv": 32,
                     "minlv": 32,
-                    "monsNo": 328
+                    "monsNo": 51
                 },
                 {
                     "maxlv": 32,
@@ -38422,8 +38452,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -38439,8 +38469,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -38456,8 +38486,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -38473,8 +38503,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -38490,8 +38520,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -38713,17 +38743,17 @@
                 {
                     "maxlv": 32,
                     "minlv": 32,
-                    "monsNo": 294
+                    "monsNo": 51
                 },
                 {
                     "maxlv": 32,
                     "minlv": 32,
-                    "monsNo": 132
+                    "monsNo": 51
                 },
                 {
                     "maxlv": 32,
                     "minlv": 32,
-                    "monsNo": 328
+                    "monsNo": 51
                 },
                 {
                     "maxlv": 32,
@@ -38755,8 +38785,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -38772,8 +38802,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -38789,8 +38819,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -38806,8 +38836,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -38823,8 +38853,8 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -38958,7 +38988,7 @@
                 {
                     "maxlv": 26,
                     "minlv": 26,
-                    "monsNo": 173
+                    "monsNo": 133
                 },
                 {
                     "maxlv": 26,
@@ -39022,7 +39052,7 @@
                 {
                     "maxlv": 26,
                     "minlv": 26,
-                    "monsNo": 173
+                    "monsNo": 133
                 },
                 {
                     "maxlv": 26,
@@ -39039,7 +39069,7 @@
                 {
                     "maxlv": 26,
                     "minlv": 26,
-                    "monsNo": 137
+                    "monsNo": 173
                 }
             ],
             "swayGrass": [
@@ -39088,8 +39118,8 @@
                     "monsNo": 216
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -39105,8 +39135,8 @@
                     "monsNo": 216
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -39122,8 +39152,8 @@
                     "monsNo": 216
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -39139,8 +39169,8 @@
                     "monsNo": 216
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -39156,8 +39186,8 @@
                     "monsNo": 216
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -39421,8 +39451,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 864
                 }
             ],
@@ -39438,8 +39468,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 864
                 }
             ],
@@ -39455,8 +39485,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 864
                 }
             ],
@@ -39472,8 +39502,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 864
                 }
             ],
@@ -39489,8 +39519,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 45,
                     "monsNo": 864
                 }
             ],
@@ -39712,17 +39742,17 @@
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 302
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 299
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 112
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
@@ -39754,9 +39784,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaSapp": [
@@ -39771,9 +39801,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaEme": [
@@ -39788,9 +39818,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaFire": [
@@ -39805,9 +39835,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaLeaf": [
@@ -39822,9 +39852,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 40,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "encRate_wat": 0,
@@ -40045,17 +40075,17 @@
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 302
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 299
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 112
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
@@ -40087,9 +40117,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaSapp": [
@@ -40104,9 +40134,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaEme": [
@@ -40121,9 +40151,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaFire": [
@@ -40138,9 +40168,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaLeaf": [
@@ -40155,9 +40185,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 40,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "encRate_wat": 0,
@@ -40342,12 +40372,12 @@
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 303
+                    "monsNo": 305
                 },
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 305
+                    "monsNo": 303
                 }
             ],
             "day": [
@@ -40378,17 +40408,17 @@
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 302
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 299
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 112
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
@@ -40420,9 +40450,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaSapp": [
@@ -40437,9 +40467,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaEme": [
@@ -40454,9 +40484,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaFire": [
@@ -40471,9 +40501,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaLeaf": [
@@ -40488,9 +40518,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 40,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "encRate_wat": 0,
@@ -40711,17 +40741,17 @@
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 302
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 299
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 112
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
@@ -40753,9 +40783,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaSapp": [
@@ -40770,9 +40800,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaEme": [
@@ -40787,9 +40817,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaFire": [
@@ -40804,9 +40834,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaLeaf": [
@@ -40821,9 +40851,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 40,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "encRate_wat": 0,
@@ -41044,17 +41074,17 @@
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 302
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 299
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 112
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
@@ -41086,9 +41116,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaSapp": [
@@ -41103,9 +41133,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaEme": [
@@ -41120,9 +41150,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaFire": [
@@ -41137,9 +41167,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaLeaf": [
@@ -41154,9 +41184,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 40,
+                    "monsNo": 0
                 }
             ],
             "encRate_wat": 0,
@@ -41377,17 +41407,17 @@
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 302
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 299
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 112
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
@@ -41419,9 +41449,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaSapp": [
@@ -41436,9 +41466,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaEme": [
@@ -41453,9 +41483,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaFire": [
@@ -41470,9 +41500,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaLeaf": [
@@ -41487,9 +41517,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 864
+                    "maxlv": 40,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "encRate_wat": 0,
@@ -41710,17 +41740,17 @@
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 92
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 19
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -41752,8 +41782,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -41769,8 +41799,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -41786,8 +41816,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -41803,8 +41833,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -41820,8 +41850,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -42043,17 +42073,17 @@
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 92
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 19
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -42085,8 +42115,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -42102,8 +42132,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -42119,8 +42149,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -42136,8 +42166,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -42153,8 +42183,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -42376,17 +42406,17 @@
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 92
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 19
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -42418,8 +42448,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -42435,8 +42465,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -42452,8 +42482,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -42469,8 +42499,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -42486,8 +42516,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -42709,17 +42739,17 @@
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 92
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 19
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -42751,8 +42781,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -42768,8 +42798,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -42785,8 +42815,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -42802,8 +42832,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -42819,8 +42849,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -43042,17 +43072,17 @@
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 92
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 19
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -43084,8 +43114,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -43101,8 +43131,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -43118,8 +43148,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -43135,8 +43165,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -43152,8 +43182,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -43375,17 +43405,17 @@
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 92
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 19
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -43417,8 +43447,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -43434,8 +43464,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -43451,8 +43481,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -43468,8 +43498,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -43485,8 +43515,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -43708,17 +43738,17 @@
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 92
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 19
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -43750,8 +43780,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -43767,8 +43797,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -43784,8 +43814,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -43801,8 +43831,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -43818,8 +43848,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -44041,17 +44071,17 @@
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 92
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 19
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -44083,8 +44113,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -44100,8 +44130,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -44117,8 +44147,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -44134,8 +44164,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -44151,8 +44181,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -44374,17 +44404,17 @@
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 92
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 19
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -44416,8 +44446,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -44433,8 +44463,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -44450,8 +44480,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -44467,8 +44497,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -44484,8 +44514,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -44749,8 +44779,8 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 5,
-                    "minlv": 5,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -44766,8 +44796,8 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 5,
-                    "minlv": 5,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -44783,8 +44813,8 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 5,
-                    "minlv": 5,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -44800,8 +44830,8 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 5,
-                    "minlv": 5,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -44817,8 +44847,8 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 5,
-                    "minlv": 5,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -44886,7 +44916,7 @@
                     "monsNo": 129
                 },
                 {
-                    "maxlv": 25,
+                    "maxlv": 20,
                     "minlv": 25,
                     "monsNo": 129
                 },
@@ -45082,8 +45112,8 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 5,
-                    "minlv": 5,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -45099,8 +45129,8 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 5,
-                    "minlv": 5,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -45116,8 +45146,8 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 5,
-                    "minlv": 5,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -45133,8 +45163,8 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 5,
-                    "minlv": 5,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -45150,8 +45180,8 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 5,
-                    "minlv": 5,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -45219,7 +45249,7 @@
                     "monsNo": 129
                 },
                 {
-                    "maxlv": 25,
+                    "maxlv": 20,
                     "minlv": 25,
                     "monsNo": 129
                 },
@@ -45491,28 +45521,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 283
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 283
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 284
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 284
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 284
                 }
             ],
@@ -45670,12 +45700,12 @@
                 {
                     "maxlv": 51,
                     "minlv": 51,
-                    "monsNo": 221
+                    "monsNo": 124
                 },
                 {
                     "maxlv": 51,
                     "minlv": 51,
-                    "monsNo": 124
+                    "monsNo": 221
                 }
             ],
             "day": [
@@ -45819,28 +45849,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 51,
+                    "minlv": 51,
                     "monsNo": 364
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 51,
+                    "minlv": 51,
                     "monsNo": 87
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 51,
+                    "minlv": 51,
                     "monsNo": 131
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 51,
+                    "minlv": 51,
                     "monsNo": 87
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 51,
+                    "minlv": 51,
                     "monsNo": 87
                 }
             ],
@@ -46003,7 +46033,7 @@
                 {
                     "maxlv": 33,
                     "minlv": 33,
-                    "monsNo": 34
+                    "monsNo": 33
                 }
             ],
             "day": [
@@ -46076,8 +46106,8 @@
                     "monsNo": 65639
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -46093,8 +46123,8 @@
                     "monsNo": 65639
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -46110,8 +46140,8 @@
                     "monsNo": 65639
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -46127,8 +46157,8 @@
                     "monsNo": 65639
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -46144,8 +46174,8 @@
                     "monsNo": 65639
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -46409,8 +46439,8 @@
                     "monsNo": 903
                 },
                 {
-                    "maxlv": 49,
-                    "minlv": 49,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -46426,8 +46456,8 @@
                     "monsNo": 903
                 },
                 {
-                    "maxlv": 49,
-                    "minlv": 49,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -46443,8 +46473,8 @@
                     "monsNo": 903
                 },
                 {
-                    "maxlv": 49,
-                    "minlv": 49,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -46460,8 +46490,8 @@
                     "monsNo": 903
                 },
                 {
-                    "maxlv": 49,
-                    "minlv": 49,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -46477,8 +46507,8 @@
                     "monsNo": 903
                 },
                 {
-                    "maxlv": 49,
-                    "minlv": 49,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -46742,8 +46772,8 @@
                     "monsNo": 65555
                 },
                 {
-                    "maxlv": 5,
-                    "minlv": 5,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -46759,8 +46789,8 @@
                     "monsNo": 65555
                 },
                 {
-                    "maxlv": 5,
-                    "minlv": 5,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -46776,8 +46806,8 @@
                     "monsNo": 65555
                 },
                 {
-                    "maxlv": 5,
-                    "minlv": 5,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -46793,8 +46823,8 @@
                     "monsNo": 65555
                 },
                 {
-                    "maxlv": 5,
-                    "minlv": 5,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -46810,8 +46840,8 @@
                     "monsNo": 65555
                 },
                 {
-                    "maxlv": 5,
-                    "minlv": 5,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -47075,8 +47105,8 @@
                     "monsNo": 65594
                 },
                 {
-                    "maxlv": 6,
-                    "minlv": 6,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -47092,8 +47122,8 @@
                     "monsNo": 65594
                 },
                 {
-                    "maxlv": 6,
-                    "minlv": 6,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -47109,8 +47139,8 @@
                     "monsNo": 65594
                 },
                 {
-                    "maxlv": 6,
-                    "minlv": 6,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -47126,8 +47156,8 @@
                     "monsNo": 65594
                 },
                 {
-                    "maxlv": 6,
-                    "minlv": 6,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -47143,8 +47173,8 @@
                     "monsNo": 65594
                 },
                 {
-                    "maxlv": 6,
-                    "minlv": 6,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -47408,8 +47438,8 @@
                     "monsNo": 65799
                 },
                 {
-                    "maxlv": 8,
-                    "minlv": 8,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -47425,8 +47455,8 @@
                     "monsNo": 65799
                 },
                 {
-                    "maxlv": 8,
-                    "minlv": 8,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -47442,8 +47472,8 @@
                     "monsNo": 65799
                 },
                 {
-                    "maxlv": 8,
-                    "minlv": 8,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -47459,8 +47489,8 @@
                     "monsNo": 65799
                 },
                 {
-                    "maxlv": 8,
-                    "minlv": 8,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -47476,8 +47506,8 @@
                     "monsNo": 65799
                 },
                 {
-                    "maxlv": 8,
-                    "minlv": 8,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -47741,8 +47771,8 @@
                     "monsNo": 25
                 },
                 {
-                    "maxlv": 7,
-                    "minlv": 7,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -47758,8 +47788,8 @@
                     "monsNo": 25
                 },
                 {
-                    "maxlv": 7,
-                    "minlv": 7,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -47775,8 +47805,8 @@
                     "monsNo": 25
                 },
                 {
-                    "maxlv": 7,
-                    "minlv": 7,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -47792,8 +47822,8 @@
                     "monsNo": 25
                 },
                 {
-                    "maxlv": 7,
-                    "minlv": 7,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -47809,8 +47839,8 @@
                     "monsNo": 25
                 },
                 {
-                    "maxlv": 7,
-                    "minlv": 7,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -48020,12 +48050,12 @@
                 {
                     "maxlv": 12,
                     "minlv": 12,
-                    "monsNo": 43
+                    "monsNo": 167
                 },
                 {
                     "maxlv": 12,
                     "minlv": 12,
-                    "monsNo": 167
+                    "monsNo": 43
                 }
             ],
             "swayGrass": [
@@ -48074,8 +48104,8 @@
                     "monsNo": 65613
                 },
                 {
-                    "maxlv": 12,
-                    "minlv": 12,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -48091,8 +48121,8 @@
                     "monsNo": 65613
                 },
                 {
-                    "maxlv": 12,
-                    "minlv": 12,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -48108,8 +48138,8 @@
                     "monsNo": 65613
                 },
                 {
-                    "maxlv": 12,
-                    "minlv": 12,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -48125,8 +48155,8 @@
                     "monsNo": 65613
                 },
                 {
-                    "maxlv": 12,
-                    "minlv": 12,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -48142,8 +48172,8 @@
                     "monsNo": 65613
                 },
                 {
-                    "maxlv": 12,
-                    "minlv": 12,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -48365,7 +48395,7 @@
                 {
                     "maxlv": 13,
                     "minlv": 13,
-                    "monsNo": 311
+                    "monsNo": 312
                 },
                 {
                     "maxlv": 13,
@@ -48375,7 +48405,7 @@
                 {
                     "maxlv": 13,
                     "minlv": 13,
-                    "monsNo": 311
+                    "monsNo": 312
                 },
                 {
                     "maxlv": 13,
@@ -48407,8 +48437,8 @@
                     "monsNo": 439
                 },
                 {
-                    "maxlv": 13,
-                    "minlv": 13,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -48424,8 +48454,8 @@
                     "monsNo": 439
                 },
                 {
-                    "maxlv": 13,
-                    "minlv": 13,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -48441,8 +48471,8 @@
                     "monsNo": 439
                 },
                 {
-                    "maxlv": 13,
-                    "minlv": 13,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -48458,8 +48488,8 @@
                     "monsNo": 439
                 },
                 {
-                    "maxlv": 13,
-                    "minlv": 13,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -48475,8 +48505,8 @@
                     "monsNo": 439
                 },
                 {
-                    "maxlv": 13,
-                    "minlv": 13,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -48740,8 +48770,8 @@
                     "monsNo": 65594
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -48757,8 +48787,8 @@
                     "monsNo": 65594
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -48774,8 +48804,8 @@
                     "monsNo": 65594
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -48791,8 +48821,8 @@
                     "monsNo": 65594
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -48808,8 +48838,8 @@
                     "monsNo": 65594
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -49073,8 +49103,8 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -49090,8 +49120,8 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -49107,8 +49137,8 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -49124,8 +49154,8 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -49141,8 +49171,8 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -49406,8 +49436,8 @@
                     "monsNo": 131124
                 },
                 {
-                    "maxlv": 10,
-                    "minlv": 10,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -49423,8 +49453,8 @@
                     "monsNo": 131124
                 },
                 {
-                    "maxlv": 10,
-                    "minlv": 10,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -49440,8 +49470,8 @@
                     "monsNo": 131124
                 },
                 {
-                    "maxlv": 10,
-                    "minlv": 10,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -49457,8 +49487,8 @@
                     "monsNo": 131124
                 },
                 {
-                    "maxlv": 10,
-                    "minlv": 10,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -49474,8 +49504,8 @@
                     "monsNo": 131124
                 },
                 {
-                    "maxlv": 10,
-                    "minlv": 10,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -49739,8 +49769,8 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -49756,8 +49786,8 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -49773,8 +49803,8 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -49790,8 +49820,8 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -49807,8 +49837,8 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -50062,86 +50092,86 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 24,
+                    "minlv": 24,
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 24,
+                    "minlv": 24,
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 24,
+                    "minlv": 24,
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 24,
+                    "minlv": 24,
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
             "gbaEme": [
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 24,
+                    "minlv": 24,
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 24,
+                    "minlv": 24,
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
             "gbaFire": [
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 24,
+                    "minlv": 24,
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 24,
+                    "minlv": 24,
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 24,
+                    "minlv": 24,
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 24,
+                    "minlv": 24,
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -50327,12 +50357,12 @@
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 42
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 93
+                    "monsNo": 42
                 }
             ],
             "day": [
@@ -50363,17 +50393,17 @@
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 198
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 200
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 356
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
@@ -50405,8 +50435,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -50422,8 +50452,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -50439,8 +50469,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -50456,8 +50486,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -50473,8 +50503,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -50608,12 +50638,12 @@
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 42
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 93
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 30,
@@ -50660,12 +50690,12 @@
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 42
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 93
+                    "monsNo": 42
                 }
             ],
             "day": [
@@ -50696,17 +50726,17 @@
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 198
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 200
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 356
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
@@ -50738,8 +50768,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -50755,8 +50785,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -50772,8 +50802,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -50789,8 +50819,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -50806,8 +50836,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -50993,12 +51023,12 @@
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 42
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 93
+                    "monsNo": 42
                 }
             ],
             "day": [
@@ -51029,17 +51059,17 @@
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 198
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 200
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 356
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
@@ -51071,8 +51101,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -51088,8 +51118,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -51105,8 +51135,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -51122,8 +51152,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -51139,8 +51169,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -51326,12 +51356,12 @@
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 42
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 93
+                    "monsNo": 42
                 }
             ],
             "day": [
@@ -51362,17 +51392,17 @@
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 198
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 200
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 356
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
@@ -51404,8 +51434,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -51421,8 +51451,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -51438,8 +51468,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -51455,8 +51485,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -51472,8 +51502,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -51607,12 +51637,12 @@
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 42
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 93
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 30,
@@ -51659,12 +51689,12 @@
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 42
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 93
+                    "monsNo": 42
                 }
             ],
             "day": [
@@ -51695,17 +51725,17 @@
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 198
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 200
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 356
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
@@ -51737,8 +51767,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -51754,8 +51784,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -51771,8 +51801,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -51788,8 +51818,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -51805,8 +51835,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -52070,8 +52100,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -52087,8 +52117,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -52104,8 +52134,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -52121,8 +52151,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -52138,8 +52168,8 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -52403,8 +52433,8 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 38,
-                    "minlv": 38,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -52420,8 +52450,8 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 38,
-                    "minlv": 38,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -52437,8 +52467,8 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 38,
-                    "minlv": 38,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -52454,8 +52484,8 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 38,
-                    "minlv": 38,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -52471,8 +52501,8 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 38,
-                    "minlv": 38,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -52736,8 +52766,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -52753,8 +52783,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -52770,8 +52800,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -52787,8 +52817,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -52804,8 +52834,8 @@
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -52991,12 +53021,12 @@
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 66
+                    "monsNo": 307
                 },
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 307
+                    "monsNo": 66
                 }
             ],
             "day": [
@@ -53069,8 +53099,8 @@
                     "monsNo": 104
                 },
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -53086,8 +53116,8 @@
                     "monsNo": 104
                 },
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -53103,8 +53133,8 @@
                     "monsNo": 104
                 },
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -53120,8 +53150,8 @@
                     "monsNo": 104
                 },
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -53137,8 +53167,8 @@
                     "monsNo": 104
                 },
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -53402,8 +53432,8 @@
                     "monsNo": 216
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -53419,8 +53449,8 @@
                     "monsNo": 216
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -53436,8 +53466,8 @@
                     "monsNo": 216
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -53453,8 +53483,8 @@
                     "monsNo": 216
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -53470,8 +53500,8 @@
                     "monsNo": 216
                 },
                 {
-                    "maxlv": 26,
-                    "minlv": 26,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -53625,6 +53655,16 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
+                    "monsNo": 24
+                },
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 454
+                },
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 109
                 },
                 {
@@ -53635,22 +53675,12 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 24
+                    "monsNo": 109
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 454
-                },
-                {
-                    "maxlv": 36,
-                    "minlv": 36,
-                    "monsNo": 24
-                },
-                {
-                    "maxlv": 36,
-                    "minlv": 36,
-                    "monsNo": 454
+                    "monsNo": 23
                 }
             ],
             "tairyo": [
@@ -53693,7 +53723,7 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 110
+                    "monsNo": 89
                 },
                 {
                     "maxlv": 36,
@@ -53703,7 +53733,7 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 110
+                    "monsNo": 89
                 },
                 {
                     "maxlv": 36,
@@ -53735,8 +53765,8 @@
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -53752,8 +53782,8 @@
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -53769,8 +53799,8 @@
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -53786,8 +53816,8 @@
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -53803,8 +53833,8 @@
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 36,
-                    "minlv": 36,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -53943,7 +53973,7 @@
                 {
                     "maxlv": 34,
                     "minlv": 34,
-                    "monsNo": 433
+                    "monsNo": 441
                 },
                 {
                     "maxlv": 34,
@@ -54068,8 +54098,8 @@
                     "monsNo": 65800
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -54085,8 +54115,8 @@
                     "monsNo": 65800
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -54102,8 +54132,8 @@
                     "monsNo": 65800
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -54119,8 +54149,8 @@
                     "monsNo": 65800
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -54136,8 +54166,8 @@
                     "monsNo": 65800
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -54401,8 +54431,8 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -54418,8 +54448,8 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -54435,8 +54465,8 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -54452,8 +54482,8 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -54469,8 +54499,8 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 32,
-                    "minlv": 32,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65615
                 }
             ],
@@ -54734,8 +54764,8 @@
                     "monsNo": 102
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -54751,8 +54781,8 @@
                     "monsNo": 102
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -54768,8 +54798,8 @@
                     "monsNo": 102
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -54785,8 +54815,8 @@
                     "monsNo": 102
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -54802,8 +54832,8 @@
                     "monsNo": 103
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 30,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -55067,8 +55097,8 @@
                     "monsNo": 65573
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -55084,8 +55114,8 @@
                     "monsNo": 65573
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -55101,8 +55131,8 @@
                     "monsNo": 65573
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -55118,8 +55148,8 @@
                     "monsNo": 65573
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -55135,8 +55165,8 @@
                     "monsNo": 65573
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -55400,8 +55430,8 @@
                     "monsNo": 65658
                 },
                 {
-                    "maxlv": 48,
-                    "minlv": 48,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -55417,8 +55447,8 @@
                     "monsNo": 65658
                 },
                 {
-                    "maxlv": 48,
-                    "minlv": 48,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -55434,8 +55464,8 @@
                     "monsNo": 65658
                 },
                 {
-                    "maxlv": 48,
-                    "minlv": 48,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -55451,8 +55481,8 @@
                     "monsNo": 65658
                 },
                 {
-                    "maxlv": 48,
-                    "minlv": 48,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -55468,8 +55498,8 @@
                     "monsNo": 65658
                 },
                 {
-                    "maxlv": 48,
-                    "minlv": 48,
+                    "maxlv": 0,
+                    "minlv": 0,
                     "monsNo": 0
                 }
             ],
@@ -55691,12 +55721,12 @@
                 {
                     "maxlv": 39,
                     "minlv": 39,
-                    "monsNo": 122
+                    "monsNo": 125
                 },
                 {
                     "maxlv": 39,
                     "minlv": 39,
-                    "monsNo": 101
+                    "monsNo": 125
                 },
                 {
                     "maxlv": 39,
@@ -55733,8 +55763,8 @@
                     "monsNo": 65587
                 },
                 {
-                    "maxlv": 39,
-                    "minlv": 39,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65615
                 }
             ],
@@ -55750,8 +55780,8 @@
                     "monsNo": 65587
                 },
                 {
-                    "maxlv": 39,
-                    "minlv": 39,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65615
                 }
             ],
@@ -55767,8 +55797,8 @@
                     "monsNo": 65587
                 },
                 {
-                    "maxlv": 39,
-                    "minlv": 39,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65615
                 }
             ],
@@ -55784,8 +55814,8 @@
                     "monsNo": 65587
                 },
                 {
-                    "maxlv": 39,
-                    "minlv": 39,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65615
                 }
             ],
@@ -55801,8 +55831,8 @@
                     "monsNo": 65587
                 },
                 {
-                    "maxlv": 39,
-                    "minlv": 39,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65615
                 }
             ],
@@ -56066,8 +56096,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
@@ -56083,8 +56113,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
@@ -56100,8 +56130,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
@@ -56117,8 +56147,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
@@ -56134,8 +56164,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
@@ -56357,12 +56387,7 @@
                 {
                     "maxlv": 40,
                     "minlv": 40,
-                    "monsNo": 85
-                },
-                {
-                    "maxlv": 40,
-                    "minlv": 40,
-                    "monsNo": 203
+                    "monsNo": 30
                 },
                 {
                     "maxlv": 40,
@@ -56372,7 +56397,12 @@
                 {
                     "maxlv": 40,
                     "minlv": 40,
-                    "monsNo": 33
+                    "monsNo": 30
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
+                    "monsNo": 30
                 }
             ],
             "FormProb": [
@@ -56399,8 +56429,8 @@
                     "monsNo": 863
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
@@ -56416,8 +56446,8 @@
                     "monsNo": 863
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
@@ -56433,8 +56463,8 @@
                     "monsNo": 863
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
@@ -56450,8 +56480,8 @@
                     "monsNo": 863
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
@@ -56467,8 +56497,8 @@
                     "monsNo": 863
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
@@ -56654,7 +56684,7 @@
                 {
                     "maxlv": 54,
                     "minlv": 54,
-                    "monsNo": 403
+                    "monsNo": 404
                 },
                 {
                     "maxlv": 54,
@@ -56732,8 +56762,8 @@
                     "monsNo": 65562
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 864
                 }
             ],
@@ -56749,8 +56779,8 @@
                     "monsNo": 65562
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 864
                 }
             ],
@@ -56766,8 +56796,8 @@
                     "monsNo": 65562
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 864
                 }
             ],
@@ -56783,8 +56813,8 @@
                     "monsNo": 65562
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 864
                 }
             ],
@@ -56800,8 +56830,8 @@
                     "monsNo": 65562
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 864
                 }
             ],
@@ -56987,7 +57017,7 @@
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 13
+                    "monsNo": 70
                 },
                 {
                     "maxlv": 59,
@@ -57023,17 +57053,17 @@
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 315
+                    "monsNo": 178
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 65959
+                    "monsNo": 178
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 213
+                    "monsNo": 178
                 },
                 {
                     "maxlv": 59,
@@ -57065,8 +57095,8 @@
                     "monsNo": 65637
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -57082,8 +57112,8 @@
                     "monsNo": 65637
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -57099,8 +57129,8 @@
                     "monsNo": 65637
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -57116,8 +57146,8 @@
                     "monsNo": 65637
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -57133,8 +57163,8 @@
                     "monsNo": 65637
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -57356,17 +57386,17 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 20
+                    "monsNo": 326
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 57
+                    "monsNo": 326
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 297
+                    "monsNo": 326
                 },
                 {
                     "maxlv": 67,
@@ -57558,28 +57588,28 @@
             "encRate_sugoi": 100,
             "sugoi_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 }
             ]
@@ -57689,17 +57719,17 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 327
+                    "monsNo": 207
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 324
+                    "monsNo": 207
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 227
+                    "monsNo": 207
                 },
                 {
                     "maxlv": 67,
@@ -57891,28 +57921,28 @@
             "encRate_sugoi": 100,
             "sugoi_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 }
             ]
@@ -58022,12 +58052,12 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 329
+                    "monsNo": 450
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 344
+                    "monsNo": 450
                 },
                 {
                     "maxlv": 67,
@@ -58100,7 +58130,7 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 0
+                    "monsNo": 864
                 }
             ],
             "gbaFire": [
@@ -58224,28 +58254,28 @@
             "encRate_sugoi": 100,
             "sugoi_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 }
             ]
@@ -58355,17 +58385,17 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 49
+                    "monsNo": 313
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 315
+                    "monsNo": 313
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 314
+                    "monsNo": 313
                 },
                 {
                     "maxlv": 67,
@@ -58557,28 +58587,28 @@
             "encRate_sugoi": 100,
             "sugoi_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 119
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 119
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 119
                 }
             ]
@@ -58730,8 +58760,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -58747,8 +58777,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -58764,8 +58794,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -58781,8 +58811,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -58798,8 +58828,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65747
                 }
             ],
@@ -59063,8 +59093,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -59080,8 +59110,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -59097,8 +59127,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -59114,8 +59144,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -59131,8 +59161,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65758
                 }
             ],
@@ -59396,8 +59426,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 904
                 }
             ],
@@ -59413,8 +59443,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 904
                 }
             ],
@@ -59430,8 +59460,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 904
                 }
             ],
@@ -59447,8 +59477,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 904
                 }
             ],
@@ -59464,8 +59494,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 904
                 }
             ],
@@ -59473,27 +59503,27 @@
             "water_mons": [
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 },
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 },
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 },
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 },
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 }
             ],
@@ -59501,27 +59531,27 @@
             "boro_mons": [
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 },
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 },
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 },
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 },
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 }
             ],
@@ -59529,27 +59559,27 @@
             "ii_mons": [
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 },
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 },
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 },
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 },
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 }
             ],
@@ -59557,27 +59587,27 @@
             "sugoi_mons": [
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 },
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 },
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 },
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 },
                 {
                     "maxlv": 100,
-                    "minlv": 100,
+                    "minlv": 1,
                     "monsNo": 129
                 }
             ]
@@ -59589,12 +59619,12 @@
                 {
                     "maxlv": 0,
                     "minlv": 0,
-                    "monsNo": 279
+                    "monsNo": 0
                 },
                 {
                     "maxlv": 0,
                     "minlv": 0,
-                    "monsNo": 419
+                    "monsNo": 0
                 },
                 {
                     "maxlv": 0,
@@ -59719,86 +59749,86 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 862
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 862
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 862
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 862
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
             "gbaEme": [
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 862
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 862
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
             "gbaFire": [
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 862
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 862
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 862
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 862
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
@@ -60062,8 +60092,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -60079,8 +60109,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -60096,8 +60126,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -60113,8 +60143,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -60130,8 +60160,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -60353,17 +60383,17 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 78
+                    "monsNo": 28
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 85
+                    "monsNo": 28
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 24
+                    "monsNo": 28
                 },
                 {
                     "maxlv": 67,
@@ -60555,28 +60585,28 @@
             "encRate_sugoi": 100,
             "sugoi_mons": [
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 117
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 369
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 369
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 369
                 }
             ]
@@ -60686,12 +60716,12 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 336
+                    "monsNo": 235
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 335
+                    "monsNo": 235
                 },
                 {
                     "maxlv": 67,
@@ -60720,12 +60750,12 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
                     "maxlv": 67,
@@ -60737,12 +60767,12 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
                     "maxlv": 67,
@@ -60754,12 +60784,12 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
                     "maxlv": 67,
@@ -60771,12 +60801,12 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
                     "maxlv": 67,
@@ -60788,12 +60818,12 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66399
+                    "monsNo": 862
                 },
                 {
                     "maxlv": 67,
@@ -60888,28 +60918,28 @@
             "encRate_sugoi": 100,
             "sugoi_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 222
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 321
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 321
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 321
                 }
             ]

--- a/input/FieldEncountTable_p.json
+++ b/input/FieldEncountTable_p.json
@@ -157,8 +157,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 904
                 }
             ],
@@ -174,8 +174,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 904
                 }
             ],
@@ -191,8 +191,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 904
                 }
             ],
@@ -208,8 +208,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 904
                 }
             ],
@@ -226,35 +226,35 @@
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 45,
                     "monsNo": 904
                 }
             ],
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 40,
-                    "minlv": 30,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 72
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 30,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 422
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 423
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 423
                 }
             ],
@@ -490,7 +490,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -507,7 +507,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -524,7 +524,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -541,7 +541,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -558,7 +558,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -566,28 +566,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 54
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 54
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 54
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 55
                 }
             ],
@@ -823,7 +823,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -840,7 +840,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -857,7 +857,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -874,7 +874,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -891,7 +891,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -899,28 +899,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 72
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65958
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 423
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 423
                 }
             ],
@@ -1156,8 +1156,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -1173,8 +1173,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -1190,8 +1190,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -1207,8 +1207,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -1224,8 +1224,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -1233,27 +1233,27 @@
             "water_mons": [
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 279
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 226
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 226
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 226
                 }
             ],
@@ -1489,8 +1489,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 65735
                 }
             ],
@@ -1506,8 +1506,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 65735
                 }
             ],
@@ -1523,8 +1523,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 65735
                 }
             ],
@@ -1540,8 +1540,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 65735
                 }
             ],
@@ -1557,8 +1557,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 65735
                 }
             ],
@@ -1566,27 +1566,27 @@
             "water_mons": [
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 279
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 226
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 226
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 226
                 }
             ],
@@ -1681,22 +1681,22 @@
             "ground_mons": [
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 41
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 328
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 293
                 },
                 {
@@ -1706,7 +1706,7 @@
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 304
                 },
                 {
@@ -1743,58 +1743,58 @@
             "tairyo": [
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 328
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 293
                 }
             ],
             "day": [
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 328
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 293
                 }
             ],
             "night": [
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 328
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 293
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 10,
-                    "minlv": 9,
-                    "monsNo": 293
+                    "minlv": 10,
+                    "monsNo": 41
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
-                    "monsNo": 304
+                    "minlv": 10,
+                    "monsNo": 41
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
-                    "monsNo": 95
+                    "minlv": 10,
+                    "monsNo": 41
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 41
                 }
             ],
@@ -1887,7 +1887,7 @@
                 {
                     "maxlv": 10,
                     "minlv": 10,
-                    "monsNo": 65587
+                    "monsNo": 65586
                 },
                 {
                     "maxlv": 0,
@@ -2014,12 +2014,12 @@
             "ground_mons": [
                 {
                     "maxlv": 11,
-                    "minlv": 10,
+                    "minlv": 11,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 11,
-                    "minlv": 10,
+                    "minlv": 11,
                     "monsNo": 41
                 },
                 {
@@ -2029,7 +2029,7 @@
                 },
                 {
                     "maxlv": 11,
-                    "minlv": 10,
+                    "minlv": 11,
                     "monsNo": 293
                 },
                 {
@@ -2039,7 +2039,7 @@
                 },
                 {
                     "maxlv": 11,
-                    "minlv": 10,
+                    "minlv": 11,
                     "monsNo": 304
                 },
                 {
@@ -2081,7 +2081,7 @@
                 },
                 {
                     "maxlv": 11,
-                    "minlv": 10,
+                    "minlv": 11,
                     "monsNo": 293
                 }
             ],
@@ -2093,7 +2093,7 @@
                 },
                 {
                     "maxlv": 11,
-                    "minlv": 10,
+                    "minlv": 11,
                     "monsNo": 293
                 }
             ],
@@ -2105,29 +2105,29 @@
                 },
                 {
                     "maxlv": 11,
-                    "minlv": 10,
+                    "minlv": 11,
                     "monsNo": 293
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 11,
-                    "minlv": 10,
-                    "monsNo": 293
+                    "minlv": 11,
+                    "monsNo": 74
                 },
                 {
                     "maxlv": 11,
-                    "minlv": 10,
-                    "monsNo": 304
+                    "minlv": 11,
+                    "monsNo": 74
                 },
                 {
                     "maxlv": 11,
-                    "minlv": 10,
-                    "monsNo": 95
+                    "minlv": 11,
+                    "monsNo": 74
                 },
                 {
                     "maxlv": 11,
-                    "minlv": 10,
+                    "minlv": 11,
                     "monsNo": 74
                 }
             ],
@@ -2347,37 +2347,37 @@
             "ground_mons": [
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 81
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 239
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 100
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 309
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 12,
+                    "minlv": 13,
                     "monsNo": 100
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 12,
+                    "minlv": 13,
                     "monsNo": 309
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 425
                 },
                 {
@@ -2387,12 +2387,12 @@
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 417
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 12,
+                    "minlv": 13,
                     "monsNo": 417
                 },
                 {
@@ -2409,49 +2409,44 @@
             "tairyo": [
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 100
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 309
                 }
             ],
             "day": [
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 100
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 309
                 }
             ],
             "night": [
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 100
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 309
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 13,
-                    "minlv": 12,
+                    "minlv": 13,
                     "monsNo": 311
-                },
-                {
-                    "maxlv": 13,
-                    "minlv": 12,
-                    "monsNo": 312
                 },
                 {
                     "maxlv": 13,
@@ -2461,7 +2456,12 @@
                 {
                     "maxlv": 13,
                     "minlv": 13,
-                    "monsNo": 312
+                    "monsNo": 311
+                },
+                {
+                    "maxlv": 13,
+                    "minlv": 13,
+                    "monsNo": 311
                 }
             ],
             "FormProb": [
@@ -2488,7 +2488,7 @@
                     "monsNo": 65636
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -2505,7 +2505,7 @@
                     "monsNo": 65636
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -2522,7 +2522,7 @@
                     "monsNo": 65636
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -2539,7 +2539,7 @@
                     "monsNo": 65636
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -2556,7 +2556,7 @@
                     "monsNo": 65636
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -2564,28 +2564,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 422
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 72
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 423
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 73
                 }
             ],
@@ -2680,17 +2680,17 @@
             "ground_mons": [
                 {
                     "maxlv": 16,
-                    "minlv": 14,
+                    "minlv": 16,
                     "monsNo": 427
                 },
                 {
                     "maxlv": 16,
-                    "minlv": 15,
+                    "minlv": 16,
                     "monsNo": 285
                 },
                 {
                     "maxlv": 16,
-                    "minlv": 15,
+                    "minlv": 16,
                     "monsNo": 46
                 },
                 {
@@ -2700,32 +2700,32 @@
                 },
                 {
                     "maxlv": 16,
-                    "minlv": 15,
+                    "minlv": 16,
                     "monsNo": 287
                 },
                 {
                     "maxlv": 16,
-                    "minlv": 15,
+                    "minlv": 16,
                     "monsNo": 290
                 },
                 {
                     "maxlv": 16,
-                    "minlv": 14,
+                    "minlv": 16,
                     "monsNo": 427
                 },
                 {
                     "maxlv": 16,
-                    "minlv": 14,
+                    "minlv": 16,
                     "monsNo": 276
                 },
                 {
                     "maxlv": 16,
-                    "minlv": 15,
+                    "minlv": 16,
                     "monsNo": 427
                 },
                 {
                     "maxlv": 16,
-                    "minlv": 15,
+                    "minlv": 16,
                     "monsNo": 276
                 },
                 {
@@ -2742,7 +2742,7 @@
             "tairyo": [
                 {
                     "maxlv": 16,
-                    "minlv": 15,
+                    "minlv": 16,
                     "monsNo": 46
                 },
                 {
@@ -2754,7 +2754,7 @@
             "day": [
                 {
                     "maxlv": 16,
-                    "minlv": 15,
+                    "minlv": 16,
                     "monsNo": 46
                 },
                 {
@@ -2766,7 +2766,7 @@
             "night": [
                 {
                     "maxlv": 16,
-                    "minlv": 15,
+                    "minlv": 16,
                     "monsNo": 198
                 },
                 {
@@ -2778,23 +2778,23 @@
             "swayGrass": [
                 {
                     "maxlv": 16,
-                    "minlv": 15,
-                    "monsNo": 267
-                },
-                {
-                    "maxlv": 16,
-                    "minlv": 15,
-                    "monsNo": 269
+                    "minlv": 16,
+                    "monsNo": 265
                 },
                 {
                     "maxlv": 16,
                     "minlv": 16,
-                    "monsNo": 267
+                    "monsNo": 265
                 },
                 {
                     "maxlv": 16,
                     "minlv": 16,
-                    "monsNo": 269
+                    "monsNo": 265
+                },
+                {
+                    "maxlv": 16,
+                    "minlv": 16,
+                    "monsNo": 265
                 }
             ],
             "FormProb": [
@@ -3013,7 +3013,7 @@
             "ground_mons": [
                 {
                     "maxlv": 40,
-                    "minlv": 36,
+                    "minlv": 40,
                     "monsNo": 81
                 },
                 {
@@ -3023,22 +3023,22 @@
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 310
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 205
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 38,
+                    "minlv": 40,
                     "monsNo": 126
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 37,
+                    "minlv": 40,
                     "monsNo": 81
                 },
                 {
@@ -3053,80 +3053,80 @@
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 126
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 126
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 126
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 126
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 310
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 205
                 }
             ],
             "day": [
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 310
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 205
                 }
             ],
             "night": [
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 310
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 205
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 40,
-                    "minlv": 38,
+                    "minlv": 40,
                     "monsNo": 110
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 38,
+                    "minlv": 40,
                     "monsNo": 110
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 110
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 110
                 }
             ],
@@ -3144,114 +3144,114 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 38,
-                    "minlv": 38,
-                    "monsNo": 65625
-                },
-                {
-                    "maxlv": 38,
-                    "minlv": 38,
-                    "monsNo": 65625
-                },
-                {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
+                    "monsNo": 65625
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
+                    "monsNo": 65625
+                },
+                {
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 38,
-                    "minlv": 38,
-                    "monsNo": 65625
-                },
-                {
-                    "maxlv": 38,
-                    "minlv": 38,
-                    "monsNo": 65625
-                },
-                {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
+                    "monsNo": 65625
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
+                    "monsNo": 65625
+                },
+                {
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
             "gbaEme": [
                 {
-                    "maxlv": 38,
-                    "minlv": 38,
-                    "monsNo": 65625
-                },
-                {
-                    "maxlv": 38,
-                    "minlv": 38,
-                    "monsNo": 65625
-                },
-                {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
+                    "monsNo": 65625
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
+                    "monsNo": 65625
+                },
+                {
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
             "gbaFire": [
                 {
-                    "maxlv": 38,
-                    "minlv": 38,
-                    "monsNo": 65625
-                },
-                {
-                    "maxlv": 38,
-                    "minlv": 38,
-                    "monsNo": 65625
-                },
-                {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
+                    "monsNo": 65625
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
+                    "monsNo": 65625
+                },
+                {
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 38,
-                    "minlv": 38,
-                    "monsNo": 65625
-                },
-                {
-                    "maxlv": 38,
-                    "minlv": 38,
-                    "monsNo": 65625
-                },
-                {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
+                    "monsNo": 65625
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
+                    "monsNo": 65625
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 40,
-                    "minlv": 30,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 72
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 30,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 422
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 423
                 }
             ],
@@ -3346,37 +3346,37 @@
             "ground_mons": [
                 {
                     "maxlv": 23,
-                    "minlv": 22,
+                    "minlv": 23,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 23,
-                    "minlv": 22,
+                    "minlv": 23,
                     "monsNo": 436
                 },
                 {
                     "maxlv": 23,
-                    "minlv": 22,
+                    "minlv": 23,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 23,
-                    "minlv": 22,
+                    "minlv": 23,
                     "monsNo": 299
                 },
                 {
                     "maxlv": 23,
-                    "minlv": 22,
+                    "minlv": 23,
                     "monsNo": 358
                 },
                 {
                     "maxlv": 23,
-                    "minlv": 22,
+                    "minlv": 23,
                     "monsNo": 375
                 },
                 {
                     "maxlv": 23,
-                    "minlv": 22,
+                    "minlv": 23,
                     "monsNo": 42
                 },
                 {
@@ -3386,13 +3386,13 @@
                 },
                 {
                     "maxlv": 23,
-                    "minlv": 22,
-                    "monsNo": 337
+                    "minlv": 23,
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 23,
-                    "minlv": 22,
-                    "monsNo": 338
+                    "minlv": 23,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 23,
@@ -3408,54 +3408,54 @@
             "tairyo": [
                 {
                     "maxlv": 23,
-                    "minlv": 22,
+                    "minlv": 23,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 23,
-                    "minlv": 22,
+                    "minlv": 23,
                     "monsNo": 299
                 }
             ],
             "day": [
                 {
                     "maxlv": 23,
-                    "minlv": 22,
+                    "minlv": 23,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 23,
-                    "minlv": 22,
+                    "minlv": 23,
                     "monsNo": 299
                 }
             ],
             "night": [
                 {
                     "maxlv": 23,
-                    "minlv": 22,
+                    "minlv": 23,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 23,
-                    "minlv": 22,
+                    "minlv": 23,
                     "monsNo": 299
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 23,
-                    "minlv": 22,
-                    "monsNo": 358
-                },
-                {
-                    "maxlv": 23,
-                    "minlv": 22,
-                    "monsNo": 42
+                    "minlv": 23,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 23,
                     "minlv": 23,
-                    "monsNo": 338
+                    "monsNo": 337
+                },
+                {
+                    "maxlv": 23,
+                    "minlv": 23,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 23,
@@ -3487,7 +3487,7 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -3504,7 +3504,7 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -3521,7 +3521,7 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -3538,7 +3538,7 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -3555,7 +3555,7 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -3563,28 +3563,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 41
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 41
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 41
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 42
                 }
             ],
@@ -3679,7 +3679,7 @@
             "ground_mons": [
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 437
                 },
                 {
@@ -3689,27 +3689,27 @@
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 299
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 358
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 375
                 },
                 {
@@ -3719,12 +3719,12 @@
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 338
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 337
                 },
                 {
@@ -3741,54 +3741,54 @@
             "tairyo": [
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 299
                 }
             ],
             "day": [
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 299
                 }
             ],
             "night": [
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 299
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 51,
-                    "minlv": 50,
-                    "monsNo": 358
-                },
-                {
-                    "maxlv": 51,
-                    "minlv": 50,
-                    "monsNo": 42
+                    "minlv": 51,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 51,
                     "minlv": 51,
-                    "monsNo": 338
+                    "monsNo": 337
+                },
+                {
+                    "maxlv": 51,
+                    "minlv": 51,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 51,
@@ -4012,7 +4012,7 @@
             "ground_mons": [
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 437
                 },
                 {
@@ -4022,27 +4022,27 @@
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 299
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 358
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 375
                 },
                 {
@@ -4052,12 +4052,12 @@
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 338
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 337
                 },
                 {
@@ -4074,31 +4074,31 @@
             "tairyo": [
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 299
                 }
             ],
             "day": [
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 299
                 }
             ],
             "night": [
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 35
                 },
                 {
@@ -4110,18 +4110,18 @@
             "swayGrass": [
                 {
                     "maxlv": 51,
-                    "minlv": 50,
-                    "monsNo": 358
-                },
-                {
-                    "maxlv": 51,
-                    "minlv": 50,
-                    "monsNo": 42
+                    "minlv": 51,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 51,
                     "minlv": 51,
-                    "monsNo": 338
+                    "monsNo": 337
+                },
+                {
+                    "maxlv": 51,
+                    "minlv": 51,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 51,
@@ -4345,7 +4345,7 @@
             "ground_mons": [
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 460
                 },
                 {
@@ -4360,27 +4360,27 @@
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 294
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 294
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 359
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 232
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 217
                 },
                 {
@@ -4412,7 +4412,7 @@
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 294
                 }
             ],
@@ -4424,7 +4424,7 @@
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 294
                 }
             ],
@@ -4436,19 +4436,19 @@
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 294
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 36
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 36
                 },
                 {
@@ -4476,14 +4476,14 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
-                    "monsNo": 66439
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 903
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
-                    "monsNo": 66439
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 903
                 },
                 {
                     "maxlv": 0,
@@ -4493,14 +4493,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
-                    "monsNo": 66439
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 903
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
-                    "monsNo": 66439
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 903
                 },
                 {
                     "maxlv": 0,
@@ -4510,14 +4510,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
-                    "monsNo": 66439
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 903
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
-                    "monsNo": 66439
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 903
                 },
                 {
                     "maxlv": 0,
@@ -4527,14 +4527,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
-                    "monsNo": 66439
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 903
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
-                    "monsNo": 66439
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 903
                 },
                 {
                     "maxlv": 0,
@@ -4544,14 +4544,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
-                    "monsNo": 66439
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 903
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
-                    "monsNo": 65679
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 903
                 },
                 {
                     "maxlv": 0,
@@ -4678,7 +4678,7 @@
             "ground_mons": [
                 {
                     "maxlv": 52,
-                    "minlv": 51,
+                    "minlv": 52,
                     "monsNo": 460
                 },
                 {
@@ -4693,27 +4693,27 @@
                 },
                 {
                     "maxlv": 52,
-                    "minlv": 50,
+                    "minlv": 52,
                     "monsNo": 294
                 },
                 {
                     "maxlv": 52,
-                    "minlv": 51,
+                    "minlv": 52,
                     "monsNo": 294
                 },
                 {
                     "maxlv": 52,
-                    "minlv": 51,
+                    "minlv": 52,
                     "monsNo": 359
                 },
                 {
                     "maxlv": 52,
-                    "minlv": 51,
+                    "minlv": 52,
                     "monsNo": 232
                 },
                 {
                     "maxlv": 52,
-                    "minlv": 51,
+                    "minlv": 52,
                     "monsNo": 217
                 },
                 {
@@ -4745,7 +4745,7 @@
                 },
                 {
                     "maxlv": 52,
-                    "minlv": 50,
+                    "minlv": 52,
                     "monsNo": 294
                 }
             ],
@@ -4757,7 +4757,7 @@
                 },
                 {
                     "maxlv": 52,
-                    "minlv": 50,
+                    "minlv": 52,
                     "monsNo": 294
                 }
             ],
@@ -4769,19 +4769,19 @@
                 },
                 {
                     "maxlv": 52,
-                    "minlv": 50,
+                    "minlv": 52,
                     "monsNo": 294
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 52,
-                    "minlv": 51,
+                    "minlv": 52,
                     "monsNo": 36
                 },
                 {
                     "maxlv": 52,
-                    "minlv": 51,
+                    "minlv": 52,
                     "monsNo": 36
                 },
                 {
@@ -4809,13 +4809,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 52,
+                    "minlv": 52,
                     "monsNo": 65574
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 52,
+                    "minlv": 52,
                     "monsNo": 65574
                 },
                 {
@@ -4826,13 +4826,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 52,
+                    "minlv": 52,
                     "monsNo": 65574
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 52,
+                    "minlv": 52,
                     "monsNo": 65574
                 },
                 {
@@ -4843,13 +4843,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 52,
+                    "minlv": 52,
                     "monsNo": 65574
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 52,
+                    "minlv": 52,
                     "monsNo": 65574
                 },
                 {
@@ -4860,13 +4860,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 52,
+                    "minlv": 52,
                     "monsNo": 65574
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 52,
+                    "minlv": 52,
                     "monsNo": 65574
                 },
                 {
@@ -4877,13 +4877,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 52,
+                    "minlv": 52,
                     "monsNo": 65574
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 52,
+                    "minlv": 52,
                     "monsNo": 65574
                 },
                 {
@@ -5011,7 +5011,7 @@
             "ground_mons": [
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 437
                 },
                 {
@@ -5021,27 +5021,27 @@
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 50,
+                    "minlv": 53,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 50,
+                    "minlv": 53,
                     "monsNo": 299
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 358
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 375
                 },
                 {
@@ -5051,12 +5051,12 @@
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 338
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 337
                 },
                 {
@@ -5073,54 +5073,54 @@
             "tairyo": [
                 {
                     "maxlv": 53,
-                    "minlv": 50,
+                    "minlv": 53,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 50,
+                    "minlv": 53,
                     "monsNo": 299
                 }
             ],
             "day": [
                 {
                     "maxlv": 53,
-                    "minlv": 50,
+                    "minlv": 53,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 50,
+                    "minlv": 53,
                     "monsNo": 299
                 }
             ],
             "night": [
                 {
                     "maxlv": 53,
-                    "minlv": 50,
+                    "minlv": 53,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 50,
+                    "minlv": 53,
                     "monsNo": 299
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 53,
-                    "minlv": 52,
-                    "monsNo": 358
-                },
-                {
-                    "maxlv": 53,
-                    "minlv": 52,
-                    "monsNo": 42
+                    "minlv": 53,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 338
+                    "monsNo": 337
+                },
+                {
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
@@ -5142,114 +5142,114 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 50,
+                    "minlv": 50,
                     "monsNo": 65735
                 }
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 50,
+                    "minlv": 50,
                     "monsNo": 65735
                 }
             ],
             "gbaEme": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 50,
+                    "minlv": 50,
                     "monsNo": 65735
                 }
             ],
             "gbaFire": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 50,
+                    "minlv": 50,
                     "monsNo": 65735
                 }
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 50,
+                    "minlv": 50,
                     "monsNo": 65735
                 }
             ],
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 40,
-                    "minlv": 30,
-                    "monsNo": 41
-                },
-                {
-                    "maxlv": 40,
-                    "minlv": 30,
+                    "maxlv": 50,
+                    "minlv": 50,
                     "monsNo": 41
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 40,
+                    "minlv": 50,
+                    "monsNo": 41
+                },
+                {
+                    "maxlv": 50,
+                    "minlv": 50,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 40,
+                    "minlv": 50,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 40,
+                    "minlv": 50,
                     "monsNo": 42
                 }
             ],
@@ -5264,6 +5264,16 @@
                     "maxlv": 10,
                     "minlv": 10,
                     "monsNo": 116
+                },
+                {
+                    "maxlv": 10,
+                    "minlv": 10,
+                    "monsNo": 147
+                },
+                {
+                    "maxlv": 10,
+                    "minlv": 10,
+                    "monsNo": 147
                 },
                 {
                     "maxlv": 10,
@@ -5287,6 +5297,16 @@
                     "maxlv": 25,
                     "minlv": 25,
                     "monsNo": 147
+                },
+                {
+                    "maxlv": 25,
+                    "minlv": 25,
+                    "monsNo": 147
+                },
+                {
+                    "maxlv": 25,
+                    "minlv": 25,
+                    "monsNo": 147
                 }
             ],
             "encRate_sugoi": 100,
@@ -5305,6 +5325,16 @@
                     "maxlv": 50,
                     "minlv": 50,
                     "monsNo": 148
+                },
+                {
+                    "maxlv": 50,
+                    "minlv": 50,
+                    "monsNo": 148
+                },
+                {
+                    "maxlv": 50,
+                    "minlv": 50,
+                    "monsNo": 148
                 }
             ]
         },
@@ -5314,7 +5344,7 @@
             "ground_mons": [
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 75
                 },
                 {
@@ -5324,42 +5354,42 @@
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 299
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 358
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 375
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 375
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 338
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 337
                 },
                 {
@@ -5376,54 +5406,54 @@
             "tairyo": [
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 299
                 }
             ],
             "day": [
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 299
                 }
             ],
             "night": [
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 299
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 53,
-                    "minlv": 52,
-                    "monsNo": 358
-                },
-                {
-                    "maxlv": 53,
-                    "minlv": 52,
-                    "monsNo": 42
+                    "minlv": 53,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 338
+                    "monsNo": 337
+                },
+                {
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
@@ -5445,13 +5475,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
@@ -5462,13 +5492,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
@@ -5479,13 +5509,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
@@ -5496,13 +5526,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
@@ -5513,13 +5543,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
@@ -5647,7 +5677,7 @@
             "ground_mons": [
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 75
                 },
                 {
@@ -5657,27 +5687,27 @@
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 299
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 358
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 375
                 },
                 {
@@ -5687,12 +5717,7 @@
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
-                    "monsNo": 337
-                },
-                {
-                    "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 338
                 },
                 {
@@ -5704,59 +5729,64 @@
                     "maxlv": 53,
                     "minlv": 53,
                     "monsNo": 338
+                },
+                {
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 337
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 299
                 }
             ],
             "day": [
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 299
                 }
             ],
             "night": [
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 299
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 53,
-                    "minlv": 52,
-                    "monsNo": 358
-                },
-                {
-                    "maxlv": 53,
-                    "minlv": 52,
-                    "monsNo": 42
+                    "minlv": 53,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 338
+                    "monsNo": 337
+                },
+                {
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
@@ -5778,13 +5808,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
@@ -5795,13 +5825,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
@@ -5812,13 +5842,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
@@ -5829,13 +5859,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
@@ -5846,13 +5876,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
@@ -5980,7 +6010,7 @@
             "ground_mons": [
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 75
                 },
                 {
@@ -5990,43 +6020,43 @@
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
-                    "monsNo": 299
-                },
-                {
-                    "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
+                    "monsNo": 299
+                },
+                {
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 358
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 375
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 375
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 52,
-                    "monsNo": 337
-                },
-                {
-                    "maxlv": 53,
-                    "minlv": 52,
+                    "minlv": 53,
                     "monsNo": 338
+                },
+                {
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
@@ -6042,54 +6072,54 @@
             "tairyo": [
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
+                    "minlv": 53,
                     "monsNo": 299
                 }
             ],
             "day": [
                 {
                     "maxlv": 53,
-                    "minlv": 51,
-                    "monsNo": 299
+                    "minlv": 53,
+                    "monsNo": 35
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
-                    "monsNo": 35
+                    "minlv": 53,
+                    "monsNo": 299
                 }
             ],
             "night": [
                 {
                     "maxlv": 53,
-                    "minlv": 51,
-                    "monsNo": 299
+                    "minlv": 53,
+                    "monsNo": 35
                 },
                 {
                     "maxlv": 53,
-                    "minlv": 51,
-                    "monsNo": 35
+                    "minlv": 53,
+                    "monsNo": 299
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 53,
-                    "minlv": 52,
-                    "monsNo": 358
-                },
-                {
-                    "maxlv": 53,
-                    "minlv": 52,
-                    "monsNo": 42
+                    "minlv": 53,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
                     "minlv": 53,
-                    "monsNo": 338
+                    "monsNo": 337
+                },
+                {
+                    "maxlv": 53,
+                    "minlv": 53,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 53,
@@ -6111,13 +6141,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
@@ -6128,13 +6158,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
@@ -6145,13 +6175,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
@@ -6162,13 +6192,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
@@ -6179,13 +6209,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
-                    "maxlv": 52,
-                    "minlv": 52,
+                    "maxlv": 53,
+                    "minlv": 53,
                     "monsNo": 65564
                 },
                 {
@@ -6313,37 +6343,37 @@
             "ground_mons": [
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 436
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
-                    "monsNo": 299
-                },
-                {
-                    "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
+                    "monsNo": 299
+                },
+                {
+                    "maxlv": 19,
+                    "minlv": 19,
                     "monsNo": 374
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 41
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 358
                 },
                 {
@@ -6353,12 +6383,12 @@
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 338
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 337
                 },
                 {
@@ -6375,54 +6405,54 @@
             "tairyo": [
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 299
                 }
             ],
             "day": [
                 {
                     "maxlv": 19,
-                    "minlv": 18,
-                    "monsNo": 299
+                    "minlv": 19,
+                    "monsNo": 35
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
-                    "monsNo": 35
+                    "minlv": 19,
+                    "monsNo": 299
                 }
             ],
             "night": [
                 {
                     "maxlv": 19,
-                    "minlv": 18,
-                    "monsNo": 299
+                    "minlv": 19,
+                    "monsNo": 35
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
-                    "monsNo": 35
+                    "minlv": 19,
+                    "monsNo": 299
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 19,
-                    "minlv": 18,
-                    "monsNo": 374
-                },
-                {
-                    "maxlv": 19,
-                    "minlv": 18,
-                    "monsNo": 41
+                    "minlv": 19,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 338
+                    "monsNo": 337
+                },
+                {
+                    "maxlv": 19,
+                    "minlv": 19,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 19,
@@ -6646,37 +6676,37 @@
             "ground_mons": [
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 436
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 299
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 374
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 41
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 358
                 },
                 {
@@ -6686,12 +6716,12 @@
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 338
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 337
                 },
                 {
@@ -6708,54 +6738,54 @@
             "tairyo": [
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 299
                 }
             ],
             "day": [
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 299
                 }
             ],
             "night": [
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 299
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 19,
-                    "minlv": 18,
-                    "monsNo": 374
-                },
-                {
-                    "maxlv": 19,
-                    "minlv": 18,
-                    "monsNo": 41
+                    "minlv": 19,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 338
+                    "monsNo": 337
+                },
+                {
+                    "maxlv": 19,
+                    "minlv": 19,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 19,
@@ -6979,37 +7009,37 @@
             "ground_mons": [
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 436
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 173
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 374
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 433
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 41
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 299
                 },
                 {
@@ -7041,54 +7071,54 @@
             "tairyo": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 173
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 374
                 }
             ],
             "day": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 173
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 374
                 }
             ],
             "night": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 173
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 374
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 433
-                },
-                {
-                    "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 41
+                    "minlv": 18,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 338
+                    "monsNo": 337
+                },
+                {
+                    "maxlv": 18,
+                    "minlv": 18,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 18,
@@ -7312,22 +7342,22 @@
             "ground_mons": [
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 436
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 299
                 },
                 {
@@ -7342,12 +7372,12 @@
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 41
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 41
                 },
                 {
@@ -7374,54 +7404,54 @@
             "tairyo": [
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 299
                 }
             ],
             "day": [
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 299
                 }
             ],
             "night": [
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 35
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 299
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 20,
-                    "minlv": 19,
-                    "monsNo": 358
-                },
-                {
-                    "maxlv": 20,
-                    "minlv": 19,
-                    "monsNo": 375
+                    "minlv": 20,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 20,
                     "minlv": 20,
-                    "monsNo": 338
+                    "monsNo": 337
+                },
+                {
+                    "maxlv": 20,
+                    "minlv": 20,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 20,
@@ -7453,9 +7483,9 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
-                    "monsNo": 0
+                    "maxlv": 45,
+                    "minlv": 45,
+                    "monsNo": 65615
                 }
             ],
             "gbaSapp": [
@@ -7470,9 +7500,9 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
-                    "monsNo": 0
+                    "maxlv": 45,
+                    "minlv": 45,
+                    "monsNo": 65615
                 }
             ],
             "gbaEme": [
@@ -7487,9 +7517,9 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
-                    "monsNo": 0
+                    "maxlv": 45,
+                    "minlv": 45,
+                    "monsNo": 65615
                 }
             ],
             "gbaFire": [
@@ -7504,9 +7534,9 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
-                    "monsNo": 0
+                    "maxlv": 45,
+                    "minlv": 45,
+                    "monsNo": 65615
                 }
             ],
             "gbaLeaf": [
@@ -7521,36 +7551,36 @@
                     "monsNo": 65624
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
-                    "monsNo": 0
+                    "maxlv": 45,
+                    "minlv": 45,
+                    "monsNo": 65615
                 }
             ],
             "encRate_wat": 10,
             "water_mons": [
                 {
                     "maxlv": 45,
-                    "minlv": 30,
+                    "minlv": 45,
                     "monsNo": 363
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 30,
+                    "minlv": 45,
                     "monsNo": 86
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 30,
+                    "minlv": 45,
                     "monsNo": 364
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 30,
+                    "minlv": 45,
                     "monsNo": 364
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 30,
+                    "minlv": 45,
                     "monsNo": 364
                 }
             ],
@@ -7644,28 +7674,28 @@
             "encRate_gr": 35,
             "ground_mons": [
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 400
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 195
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
-                    "monsNo": 114
-                },
-                {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 357
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 114
+                },
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 455
                 },
                 {
@@ -7674,23 +7704,23 @@
                     "monsNo": 357
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 114
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 114
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 400
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 400
                 },
                 {
@@ -7706,50 +7736,50 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
-                    "monsNo": 357
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 400
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
-                    "monsNo": 114
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 195
                 }
             ],
             "day": [
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
-                    "monsNo": 114
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 357
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
-                    "monsNo": 357
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 114
                 }
             ],
             "night": [
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
-                    "monsNo": 114
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 357
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
-                    "monsNo": 357
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 114
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
-                    "monsNo": 455
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 400
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
-                    "monsNo": 357
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 400
                 },
                 {
                     "maxlv": 36,
@@ -7776,85 +7806,85 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaEme": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaFire": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -7862,28 +7892,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 194
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 194
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 194
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 195
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 195
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 195
                 }
             ],
@@ -7977,28 +8007,28 @@
             "encRate_gr": 35,
             "ground_mons": [
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 400
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 195
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 357
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 114
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 455
                 },
                 {
@@ -8007,23 +8037,23 @@
                     "monsNo": 357
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 114
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 114
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 400
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 400
                 },
                 {
@@ -8039,50 +8069,50 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
-                    "monsNo": 357
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 400
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
-                    "monsNo": 114
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 195
                 }
             ],
             "day": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 357
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 114
                 }
             ],
             "night": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 357
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 114
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
-                    "monsNo": 455
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 400
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
-                    "monsNo": 357
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 400
                 },
                 {
                     "maxlv": 36,
@@ -8109,85 +8139,85 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaEme": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaFire": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -8195,28 +8225,28 @@
             "encRate_wat": 15,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 194
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 194
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 194
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 195
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 195
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 195
                 }
             ],
@@ -8310,18 +8340,18 @@
             "encRate_gr": 35,
             "ground_mons": [
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 47
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 102
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 453
                 },
                 {
@@ -8332,7 +8362,7 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 183
+                    "monsNo": 47
                 },
                 {
                     "maxlv": 36,
@@ -8340,13 +8370,13 @@
                     "monsNo": 453
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 115
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 193
                 },
                 {
@@ -8355,8 +8385,8 @@
                     "monsNo": 115
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 193
                 },
                 {
@@ -8372,20 +8402,20 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
-                    "monsNo": 453
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 47
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 454
+                    "monsNo": 102
                 }
             ],
             "day": [
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 453
                 },
                 {
@@ -8396,8 +8426,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 453
                 },
                 {
@@ -8408,24 +8438,24 @@
             ],
             "swayGrass": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
-                    "monsNo": 47
-                },
-                {
-                    "maxlv": 35,
-                    "minlv": 35,
-                    "monsNo": 453
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 193
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 115
+                    "monsNo": 193
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 469
+                    "monsNo": 193
+                },
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 193
                 }
             ],
             "FormProb": [
@@ -8442,85 +8472,85 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaEme": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaFire": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -8528,28 +8558,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 194
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 194
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 194
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 195
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 195
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 195
                 }
             ],
@@ -8643,18 +8673,18 @@
             "encRate_gr": 35,
             "ground_mons": [
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 47
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 102
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 453
                 },
                 {
@@ -8668,18 +8698,18 @@
                     "monsNo": 47
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 453
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 115
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 193
                 },
                 {
@@ -8688,8 +8718,8 @@
                     "monsNo": 115
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 193
                 },
                 {
@@ -8705,20 +8735,20 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
-                    "monsNo": 453
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 47
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 454
+                    "monsNo": 102
                 }
             ],
             "day": [
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 453
                 },
                 {
@@ -8729,8 +8759,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 453
                 },
                 {
@@ -8741,19 +8771,19 @@
             ],
             "swayGrass": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
-                    "monsNo": 47
-                },
-                {
-                    "maxlv": 35,
-                    "minlv": 35,
-                    "monsNo": 453
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 193
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 115
+                    "monsNo": 193
+                },
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 193
                 },
                 {
                     "maxlv": 36,
@@ -8775,85 +8805,85 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaEme": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaFire": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -8861,28 +8891,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 194
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 194
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 194
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 195
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 195
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 195
                 }
             ],
@@ -8976,24 +9006,29 @@
             "encRate_gr": 35,
             "ground_mons": [
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 451
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 316
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
-                    "monsNo": 451
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 285
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 285
+                },
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 451
                 },
                 {
                     "maxlv": 36,
@@ -9001,18 +9036,13 @@
                     "monsNo": 452
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
-                    "monsNo": 285
-                },
-                {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 317
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 286
                 },
                 {
@@ -9028,7 +9058,7 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 217
+                    "monsNo": 317
                 },
                 {
                     "maxlv": 36,
@@ -9038,55 +9068,55 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 451
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
-                    "monsNo": 285
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 316
                 }
             ],
             "day": [
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
-                    "monsNo": 451
-                },
-                {
-                    "maxlv": 33,
-                    "minlv": 33,
-                    "monsNo": 285
-                }
-            ],
-            "night": [
-                {
-                    "maxlv": 34,
-                    "minlv": 34,
-                    "monsNo": 451
-                },
-                {
-                    "maxlv": 33,
-                    "minlv": 33,
-                    "monsNo": 285
-                }
-            ],
-            "swayGrass": [
-                {
-                    "maxlv": 35,
-                    "minlv": 35,
-                    "monsNo": 452
-                },
-                {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 285
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 317
+                    "monsNo": 285
+                }
+            ],
+            "night": [
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 285
+                },
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 285
+                }
+            ],
+            "swayGrass": [
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 286
+                },
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 286
+                },
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 286
                 },
                 {
                     "maxlv": 36,
@@ -9108,85 +9138,85 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaEme": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaFire": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -9194,28 +9224,28 @@
             "encRate_wat": 0,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 194
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 194
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 194
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 195
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 195
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 195
                 }
             ],
@@ -9309,24 +9339,29 @@
             "encRate_gr": 35,
             "ground_mons": [
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 451
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 316
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
-                    "monsNo": 451
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 285
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 285
+                },
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 451
                 },
                 {
                     "maxlv": 36,
@@ -9334,18 +9369,13 @@
                     "monsNo": 452
                 },
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
-                    "monsNo": 285
-                },
-                {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 317
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 286
                 },
                 {
@@ -9361,7 +9391,7 @@
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 217
+                    "monsNo": 317
                 },
                 {
                     "maxlv": 36,
@@ -9371,59 +9401,59 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 451
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
-                    "monsNo": 285
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 316
                 }
             ],
             "day": [
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
-                    "monsNo": 451
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 285
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 285
                 }
             ],
             "night": [
                 {
-                    "maxlv": 34,
-                    "minlv": 34,
-                    "monsNo": 451
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 285
                 },
                 {
-                    "maxlv": 33,
-                    "minlv": 33,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 285
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
-                    "monsNo": 452
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 286
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
-                    "monsNo": 285
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 286
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
-                    "monsNo": 317
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 286
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 286
                 }
             ],
@@ -9441,85 +9471,85 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaEme": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaFire": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 35,
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 65751
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -9527,28 +9557,28 @@
             "encRate_wat": 0,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 194
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 194
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 194
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 195
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 195
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 195
                 }
             ],
@@ -9642,58 +9672,58 @@
             "encRate_gr": 10,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -9704,54 +9734,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -9774,13 +9804,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -9791,13 +9821,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -9808,13 +9838,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -9825,13 +9855,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -9842,13 +9872,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -9975,58 +10005,58 @@
             "encRate_gr": 10,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10037,54 +10067,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10107,13 +10137,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10124,13 +10154,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10141,13 +10171,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10158,13 +10188,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10175,13 +10205,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10308,58 +10338,58 @@
             "encRate_gr": 10,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10370,54 +10400,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10440,13 +10470,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10457,13 +10487,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10474,13 +10504,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10491,13 +10521,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10508,13 +10538,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10641,58 +10671,58 @@
             "encRate_gr": 10,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10703,54 +10733,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10773,13 +10803,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10790,13 +10820,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10807,13 +10837,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10824,13 +10854,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10841,13 +10871,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -10974,58 +11004,58 @@
             "encRate_gr": 10,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11036,54 +11066,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11106,13 +11136,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11123,13 +11153,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11140,13 +11170,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11157,13 +11187,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11174,13 +11204,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11307,58 +11337,58 @@
             "encRate_gr": 10,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11369,54 +11399,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11439,13 +11469,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11456,13 +11486,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11473,13 +11503,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11490,13 +11520,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11507,13 +11537,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11640,58 +11670,58 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11702,54 +11732,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11772,13 +11802,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11789,13 +11819,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11806,13 +11836,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11823,13 +11853,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11840,13 +11870,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -11973,58 +12003,58 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12035,54 +12065,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12105,13 +12135,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12122,13 +12152,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12139,13 +12169,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12156,13 +12186,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12173,13 +12203,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12306,58 +12336,58 @@
             "encRate_gr": 20,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12368,54 +12398,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12438,13 +12468,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12455,13 +12485,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12472,13 +12502,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12489,13 +12519,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12506,13 +12536,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12639,58 +12669,58 @@
             "encRate_gr": 20,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12701,54 +12731,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12771,13 +12801,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12788,13 +12818,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12805,13 +12835,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12822,13 +12852,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12839,13 +12869,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -12972,58 +13002,58 @@
             "encRate_gr": 20,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13034,54 +13064,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13104,13 +13134,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13121,13 +13151,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13138,13 +13168,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13155,13 +13185,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13172,13 +13202,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13305,58 +13335,58 @@
             "encRate_gr": 10,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13367,54 +13397,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13437,13 +13467,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13454,13 +13484,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13471,13 +13501,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13488,13 +13518,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13505,13 +13535,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13638,58 +13668,58 @@
             "encRate_gr": 10,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13700,54 +13730,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13770,13 +13800,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13787,13 +13817,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13804,13 +13834,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13821,13 +13851,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13838,13 +13868,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -13971,58 +14001,58 @@
             "encRate_gr": 10,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14033,54 +14063,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14103,13 +14133,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14120,13 +14150,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14137,13 +14167,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14154,13 +14184,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14171,13 +14201,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14304,58 +14334,58 @@
             "encRate_gr": 10,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14366,54 +14396,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14436,13 +14466,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14453,13 +14483,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14470,13 +14500,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14487,13 +14517,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14504,13 +14534,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14637,58 +14667,58 @@
             "encRate_gr": 25,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14699,54 +14729,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14769,13 +14799,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14786,13 +14816,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14803,13 +14833,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14820,13 +14850,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14837,13 +14867,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -14970,58 +15000,58 @@
             "encRate_gr": 25,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -15032,54 +15062,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -15102,13 +15132,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -15119,13 +15149,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -15136,13 +15166,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -15153,13 +15183,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -15170,13 +15200,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -15303,58 +15333,58 @@
             "encRate_gr": 30,
             "ground_mons": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 23,
-                    "minlv": 23,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -15365,54 +15395,54 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 19,
-                    "minlv": 19,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 20,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "day": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "night": [
                 {
-                    "maxlv": 18,
-                    "minlv": 18,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 21,
-                    "minlv": 21,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 22,
-                    "minlv": 22,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 14,
-                    "minlv": 14,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -15435,13 +15465,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -15452,13 +15482,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -15469,13 +15499,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -15486,13 +15516,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -15503,13 +15533,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 25,
+                    "minlv": 25,
                     "monsNo": 201
                 },
                 {
@@ -15734,19 +15764,19 @@
             ],
             "swayGrass": [
                 {
-                    "maxlv": 58,
-                    "minlv": 58,
-                    "monsNo": 297
-                },
-                {
-                    "maxlv": 58,
-                    "minlv": 58,
-                    "monsNo": 444
+                    "maxlv": 59,
+                    "minlv": 59,
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 112
+                    "monsNo": 208
+                },
+                {
+                    "maxlv": 59,
+                    "minlv": 59,
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 59,
@@ -16067,19 +16097,19 @@
             ],
             "swayGrass": [
                 {
-                    "maxlv": 58,
-                    "minlv": 58,
-                    "monsNo": 108
-                },
-                {
-                    "maxlv": 58,
-                    "minlv": 58,
-                    "monsNo": 42
+                    "maxlv": 59,
+                    "minlv": 59,
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 105
+                    "monsNo": 444
+                },
+                {
+                    "maxlv": 59,
+                    "minlv": 59,
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
@@ -16314,7 +16344,7 @@
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 76
+                    "monsNo": 75
                 },
                 {
                     "maxlv": 59,
@@ -16366,7 +16396,7 @@
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 76
+                    "monsNo": 75
                 },
                 {
                     "maxlv": 59,
@@ -16400,19 +16430,19 @@
             ],
             "swayGrass": [
                 {
-                    "maxlv": 58,
-                    "minlv": 58,
-                    "monsNo": 302
-                },
-                {
-                    "maxlv": 58,
-                    "minlv": 58,
-                    "monsNo": 87
+                    "maxlv": 59,
+                    "minlv": 59,
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 42
+                    "monsNo": 444
+                },
+                {
+                    "maxlv": 59,
+                    "minlv": 59,
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
@@ -16444,8 +16474,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16461,8 +16491,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16478,8 +16508,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16495,8 +16525,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16512,8 +16542,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 40,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16521,27 +16551,27 @@
             "water_mons": [
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 419
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 419
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 42
                 }
             ],
@@ -16733,19 +16763,19 @@
             ],
             "swayGrass": [
                 {
-                    "maxlv": 58,
-                    "minlv": 58,
-                    "monsNo": 308
-                },
-                {
-                    "maxlv": 58,
-                    "minlv": 58,
-                    "monsNo": 87
+                    "maxlv": 59,
+                    "minlv": 59,
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 42
+                    "monsNo": 444
+                },
+                {
+                    "maxlv": 59,
+                    "minlv": 59,
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
@@ -16777,8 +16807,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16794,8 +16824,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16811,8 +16841,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16828,8 +16858,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16845,8 +16875,8 @@
                     "monsNo": 65612
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 40,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -16854,27 +16884,27 @@
             "water_mons": [
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 364
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 87
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 131
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 131
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 131
                 }
             ],
@@ -17066,19 +17096,19 @@
             ],
             "swayGrass": [
                 {
-                    "maxlv": 58,
-                    "minlv": 58,
-                    "monsNo": 308
-                },
-                {
-                    "maxlv": 58,
-                    "minlv": 58,
-                    "monsNo": 208
+                    "maxlv": 59,
+                    "minlv": 59,
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 42
+                    "monsNo": 444
+                },
+                {
+                    "maxlv": 59,
+                    "minlv": 59,
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
@@ -17399,19 +17429,19 @@
             ],
             "swayGrass": [
                 {
-                    "maxlv": 58,
-                    "minlv": 58,
-                    "monsNo": 308
-                },
-                {
-                    "maxlv": 58,
-                    "minlv": 58,
-                    "monsNo": 208
+                    "maxlv": 59,
+                    "minlv": 59,
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 42
+                    "monsNo": 444
+                },
+                {
+                    "maxlv": 59,
+                    "minlv": 59,
+                    "monsNo": 444
                 },
                 {
                     "maxlv": 59,
@@ -17635,42 +17665,42 @@
             "ground_mons": [
                 {
                     "maxlv": 8,
-                    "minlv": 6,
+                    "minlv": 8,
                     "monsNo": 41
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 6,
+                    "minlv": 8,
                     "monsNo": 194
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 6,
+                    "minlv": 8,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 6,
+                    "minlv": 8,
                     "monsNo": 54
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 6,
+                    "minlv": 8,
                     "monsNo": 27
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 6,
+                    "minlv": 8,
                     "monsNo": 296
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 41
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 74
                 },
                 {
@@ -17697,58 +17727,58 @@
             "tairyo": [
                 {
                     "maxlv": 8,
-                    "minlv": 6,
+                    "minlv": 8,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 6,
+                    "minlv": 8,
                     "monsNo": 54
                 }
             ],
             "day": [
                 {
                     "maxlv": 8,
-                    "minlv": 6,
+                    "minlv": 8,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 6,
+                    "minlv": 8,
                     "monsNo": 54
                 }
             ],
             "night": [
                 {
                     "maxlv": 8,
-                    "minlv": 6,
+                    "minlv": 8,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 6,
+                    "minlv": 8,
                     "monsNo": 54
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 8,
-                    "minlv": 6,
-                    "monsNo": 41
-                },
-                {
-                    "maxlv": 8,
-                    "minlv": 6,
+                    "minlv": 8,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 6,
-                    "monsNo": 41
+                    "minlv": 8,
+                    "monsNo": 74
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 6,
+                    "minlv": 8,
+                    "monsNo": 74
+                },
+                {
+                    "maxlv": 8,
+                    "minlv": 8,
                     "monsNo": 74
                 }
             ],
@@ -17776,7 +17806,7 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -17793,7 +17823,7 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -17810,7 +17840,7 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -17827,7 +17857,7 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -17844,7 +17874,7 @@
                     "monsNo": 65610
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -17852,28 +17882,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 194
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 194
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 194
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 195
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 195
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 195
                 }
             ],
@@ -17968,32 +17998,32 @@
             "ground_mons": [
                 {
                     "maxlv": 9,
-                    "minlv": 7,
+                    "minlv": 9,
                     "monsNo": 41
                 },
                 {
                     "maxlv": 9,
-                    "minlv": 7,
+                    "minlv": 9,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 9,
-                    "minlv": 7,
+                    "minlv": 9,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 9,
-                    "minlv": 8,
+                    "minlv": 9,
                     "monsNo": 447
                 },
                 {
                     "maxlv": 9,
-                    "minlv": 8,
+                    "minlv": 9,
                     "monsNo": 41
                 },
                 {
                     "maxlv": 9,
-                    "minlv": 8,
+                    "minlv": 9,
                     "monsNo": 74
                 },
                 {
@@ -18030,53 +18060,53 @@
             "tairyo": [
                 {
                     "maxlv": 9,
-                    "minlv": 7,
+                    "minlv": 9,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 9,
-                    "minlv": 8,
+                    "minlv": 9,
                     "monsNo": 447
                 }
             ],
             "day": [
                 {
                     "maxlv": 9,
-                    "minlv": 7,
+                    "minlv": 9,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 9,
-                    "minlv": 8,
+                    "minlv": 9,
                     "monsNo": 447
                 }
             ],
             "night": [
                 {
                     "maxlv": 9,
-                    "minlv": 7,
+                    "minlv": 9,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 9,
-                    "minlv": 8,
+                    "minlv": 9,
                     "monsNo": 447
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 9,
-                    "minlv": 8,
-                    "monsNo": 41
+                    "minlv": 9,
+                    "monsNo": 50
                 },
                 {
                     "maxlv": 9,
-                    "minlv": 8,
-                    "monsNo": 74
+                    "minlv": 9,
+                    "monsNo": 50
                 },
                 {
                     "maxlv": 9,
-                    "minlv": 8,
+                    "minlv": 9,
                     "monsNo": 50
                 },
                 {
@@ -18301,27 +18331,27 @@
             "ground_mons": [
                 {
                     "maxlv": 10,
-                    "minlv": 8,
+                    "minlv": 10,
                     "monsNo": 41
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 8,
+                    "minlv": 10,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 8,
+                    "minlv": 10,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 447
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 41
                 },
                 {
@@ -18336,17 +18366,17 @@
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 50
                 },
                 {
@@ -18363,58 +18393,58 @@
             "tairyo": [
                 {
                     "maxlv": 10,
-                    "minlv": 8,
+                    "minlv": 10,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 447
                 }
             ],
             "day": [
                 {
                     "maxlv": 10,
-                    "minlv": 8,
+                    "minlv": 10,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 447
                 }
             ],
             "night": [
                 {
                     "maxlv": 10,
-                    "minlv": 8,
+                    "minlv": 10,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 447
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 10,
-                    "minlv": 9,
-                    "monsNo": 41
-                },
-                {
-                    "maxlv": 10,
-                    "minlv": 9,
-                    "monsNo": 74
-                },
-                {
-                    "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
+                    "monsNo": 50
+                },
+                {
+                    "maxlv": 10,
+                    "minlv": 10,
+                    "monsNo": 50
+                },
+                {
+                    "maxlv": 10,
+                    "minlv": 10,
                     "monsNo": 50
                 }
             ],
@@ -18442,7 +18472,7 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -18459,7 +18489,7 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -18476,7 +18506,7 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -18493,7 +18523,7 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -18510,7 +18540,7 @@
                     "monsNo": 65586
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -18518,28 +18548,28 @@
             "encRate_wat": 0,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 41
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 41
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 41
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 42
                 }
             ],
@@ -18634,120 +18664,120 @@
             "ground_mons": [
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 22
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 112
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 126
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 66,
+                    "minlv": 69,
                     "monsNo": 67
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 227
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 66,
+                    "minlv": 69,
                     "monsNo": 207
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 323
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 324
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 323
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 324
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 323
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 324
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 126
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 66,
+                    "minlv": 69,
                     "monsNo": 67
                 }
             ],
             "day": [
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 126
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 66,
+                    "minlv": 69,
                     "monsNo": 67
                 }
             ],
             "night": [
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 126
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 66,
+                    "minlv": 69,
                     "monsNo": 67
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 69,
-                    "minlv": 67,
-                    "monsNo": 227
+                    "minlv": 69,
+                    "monsNo": 324
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 67,
-                    "monsNo": 207
+                    "minlv": 69,
+                    "monsNo": 324
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 68,
-                    "monsNo": 323
+                    "minlv": 69,
+                    "monsNo": 324
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 324
                 }
             ],
@@ -18967,7 +18997,7 @@
             "ground_mons": [
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 42
                 },
                 {
@@ -18977,27 +19007,27 @@
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 219
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 67
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 324
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 110
                 },
                 {
@@ -19029,54 +19059,54 @@
             "tairyo": [
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 219
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 75
                 }
             ],
             "day": [
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 219
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 75
                 }
             ],
             "night": [
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 219
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 75
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 69,
-                    "minlv": 68,
-                    "monsNo": 67
-                },
-                {
-                    "maxlv": 69,
-                    "minlv": 68,
-                    "monsNo": 324
+                    "minlv": 69,
+                    "monsNo": 89
                 },
                 {
                     "maxlv": 69,
                     "minlv": 69,
-                    "monsNo": 110
+                    "monsNo": 89
+                },
+                {
+                    "maxlv": 69,
+                    "minlv": 69,
+                    "monsNo": 89
                 },
                 {
                     "maxlv": 69,
@@ -19300,7 +19330,7 @@
             "ground_mons": [
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 219
                 },
                 {
@@ -19310,37 +19340,37 @@
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 67
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 324
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 110
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 89
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 29,
+                    "minlv": 69,
                     "monsNo": 110
                 },
                 {
@@ -19362,54 +19392,54 @@
             "tairyo": [
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 75
                 }
             ],
             "day": [
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 67,
+                    "minlv": 69,
                     "monsNo": 75
                 }
             ],
             "night": [
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 69,
-                    "minlv": 68,
+                    "minlv": 69,
                     "monsNo": 75
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 69,
-                    "minlv": 68,
-                    "monsNo": 67
-                },
-                {
-                    "maxlv": 69,
-                    "minlv": 68,
-                    "monsNo": 324
+                    "minlv": 69,
+                    "monsNo": 89
                 },
                 {
                     "maxlv": 69,
                     "minlv": 69,
-                    "monsNo": 110
+                    "monsNo": 89
+                },
+                {
+                    "maxlv": 69,
+                    "minlv": 69,
+                    "monsNo": 89
                 },
                 {
                     "maxlv": 69,
@@ -19633,7 +19663,7 @@
             "ground_mons": [
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 397
                 },
                 {
@@ -19643,7 +19673,7 @@
                 },
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 358
                 },
                 {
@@ -19668,7 +19698,7 @@
                 },
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 397
                 },
                 {
@@ -19695,7 +19725,7 @@
             "tairyo": [
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 358
                 },
                 {
@@ -19707,7 +19737,7 @@
             "day": [
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 358
                 },
                 {
@@ -19719,7 +19749,7 @@
             "night": [
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 358
                 },
                 {
@@ -19731,12 +19761,12 @@
             "swayGrass": [
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 202
                 },
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 202
                 },
                 {
@@ -19774,8 +19804,8 @@
                     "monsNo": 864
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 65735
                 }
             ],
@@ -19791,8 +19821,8 @@
                     "monsNo": 864
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 65735
                 }
             ],
@@ -19808,8 +19838,8 @@
                     "monsNo": 864
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 65735
                 }
             ],
@@ -19825,8 +19855,8 @@
                     "monsNo": 864
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 65735
                 }
             ],
@@ -19842,8 +19872,8 @@
                     "monsNo": 864
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 54,
+                    "minlv": 55,
                     "monsNo": 65735
                 }
             ],
@@ -19851,27 +19881,27 @@
             "water_mons": [
                 {
                     "maxlv": 55,
-                    "minlv": 45,
+                    "minlv": 55,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 55,
-                    "minlv": 45,
+                    "minlv": 55,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 55,
-                    "minlv": 45,
+                    "minlv": 55,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 55,
-                    "minlv": 45,
+                    "minlv": 55,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 55,
-                    "minlv": 45,
+                    "minlv": 55,
                     "monsNo": 55
                 }
             ],
@@ -19965,23 +19995,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -19990,18 +20020,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -20027,59 +20057,59 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
-                    "monsNo": 358
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 337
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 }
             ],
@@ -20155,7 +20185,7 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 65694
+                    "monsNo": 65693
                 },
                 {
                     "maxlv": 0,
@@ -20167,7 +20197,7 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 65694
+                    "monsNo": 65693
                 },
                 {
                     "maxlv": 66,
@@ -20298,23 +20328,23 @@
             "encRate_gr": 10,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -20323,18 +20353,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -20360,59 +20390,59 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
-                    "monsNo": 358
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 337
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 }
             ],
@@ -20631,23 +20661,23 @@
             "encRate_gr": 10,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -20656,18 +20686,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -20694,59 +20724,59 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
-                    "monsNo": 93
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -20964,23 +20994,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -20989,18 +21019,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -21027,59 +21057,59 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 46,
-                    "minlv": 46,
-                    "monsNo": 93
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 44,
-                    "minlv": 44,
-                    "monsNo": 436
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 46,
-                    "minlv": 46,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -21297,23 +21327,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -21322,18 +21352,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -21360,59 +21390,59 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 46,
-                    "minlv": 46,
-                    "monsNo": 93
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 44,
-                    "minlv": 44,
-                    "monsNo": 436
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 46,
-                    "minlv": 46,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -21630,23 +21660,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -21655,18 +21685,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -21693,59 +21723,59 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 46,
-                    "minlv": 46,
-                    "monsNo": 93
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 44,
-                    "minlv": 44,
-                    "monsNo": 436
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 46,
-                    "minlv": 46,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -21963,23 +21993,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -21988,18 +22018,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -22026,59 +22056,59 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 46,
-                    "minlv": 46,
-                    "monsNo": 93
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 44,
-                    "minlv": 44,
-                    "monsNo": 436
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 46,
-                    "minlv": 46,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -22296,23 +22326,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -22321,18 +22351,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -22359,59 +22389,59 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 46,
-                    "minlv": 46,
-                    "monsNo": 93
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 44,
-                    "minlv": 44,
-                    "monsNo": 436
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 46,
-                    "minlv": 46,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -22629,24 +22659,24 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
-                    "monsNo": 354
+                    "minlv": 66,
+                    "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
-                    "monsNo": 356
+                    "minlv": 66,
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 66,
@@ -22654,18 +22684,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -22692,59 +22722,59 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
-                    "monsNo": 354
+                    "minlv": 66,
+                    "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
-                    "monsNo": 356
+                    "minlv": 66,
+                    "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 46,
-                    "minlv": 46,
-                    "monsNo": 93
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 45,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 44,
-                    "minlv": 44,
-                    "monsNo": 436
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 46,
-                    "minlv": 46,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -22962,23 +22992,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -22987,18 +23017,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -23025,59 +23055,59 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
-                    "monsNo": 93
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -23295,23 +23325,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -23320,18 +23350,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -23358,59 +23388,59 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
-                    "monsNo": 93
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -23628,23 +23658,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -23653,18 +23683,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -23691,59 +23721,59 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
-                    "monsNo": 93
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -23961,23 +23991,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -23986,18 +24016,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -24024,59 +24054,59 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
-                    "monsNo": 93
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -24294,23 +24324,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -24319,18 +24349,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -24357,59 +24387,59 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
-                    "monsNo": 93
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -24627,23 +24657,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -24652,18 +24682,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -24690,59 +24720,59 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
-                    "monsNo": 93
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 },
                 {
-                    "maxlv": 56,
-                    "minlv": 56,
-                    "monsNo": 437
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -24960,23 +24990,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -24985,18 +25015,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -25023,36 +25053,36 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
@@ -25060,22 +25090,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 65,
-                    "minlv": 65,
-                    "monsNo": 437
-                },
-                {
-                    "maxlv": 64,
-                    "minlv": 64,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
+                },
+                {
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
+                },
+                {
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -25293,23 +25323,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -25318,18 +25348,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -25356,36 +25386,36 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
@@ -25393,22 +25423,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 65,
-                    "minlv": 65,
-                    "monsNo": 437
-                },
-                {
-                    "maxlv": 64,
-                    "minlv": 64,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
+                },
+                {
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
+                },
+                {
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -25626,23 +25656,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -25651,18 +25681,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -25689,36 +25719,36 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
@@ -25726,22 +25756,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 65,
-                    "minlv": 65,
-                    "monsNo": 437
-                },
-                {
-                    "maxlv": 64,
-                    "minlv": 64,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
+                },
+                {
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
+                },
+                {
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -25959,23 +25989,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -25984,18 +26014,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -26022,36 +26052,36 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
@@ -26059,22 +26089,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 65,
-                    "minlv": 65,
-                    "monsNo": 437
-                },
-                {
-                    "maxlv": 64,
-                    "minlv": 64,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
+                },
+                {
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
+                },
+                {
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -26292,23 +26322,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -26317,18 +26347,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -26355,36 +26385,36 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
@@ -26392,22 +26422,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 65,
-                    "minlv": 65,
-                    "monsNo": 437
-                },
-                {
-                    "maxlv": 64,
-                    "minlv": 64,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
+                },
+                {
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
+                },
+                {
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -26625,23 +26655,23 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 42
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 },
                 {
@@ -26650,18 +26680,18 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 358
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 337
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 66,
+                    "minlv": 66,
                     "monsNo": 338
                 },
                 {
@@ -26688,36 +26718,36 @@
             "tairyo": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "day": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
             "night": [
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 66,
-                    "minlv": 65,
+                    "minlv": 66,
                     "monsNo": 354
                 }
             ],
@@ -26725,22 +26755,22 @@
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 65,
-                    "minlv": 65,
-                    "monsNo": 437
-                },
-                {
-                    "maxlv": 64,
-                    "minlv": 64,
-                    "monsNo": 436
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 66,
                     "minlv": 66,
-                    "monsNo": 437
+                    "monsNo": 338
+                },
+                {
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
+                },
+                {
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 338
                 }
             ],
             "FormProb": [
@@ -26756,23 +26786,6 @@
                 0
             ],
             "gbaRuby": [
-                {
-                    "maxlv": 66,
-                    "minlv": 66,
-                    "monsNo": 65693
-                },
-                {
-                    "maxlv": 66,
-                    "minlv": 66,
-                    "monsNo": 65693
-                },
-                {
-                    "maxlv": 0,
-                    "minlv": 0,
-                    "monsNo": 0
-                }
-            ],
-            "gbaSapp": [
                 {
                     "maxlv": 66,
                     "minlv": 66,
@@ -26789,6 +26802,23 @@
                     "monsNo": 0
                 }
             ],
+            "gbaSapp": [
+                {
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 65693
+                },
+                {
+                    "maxlv": 66,
+                    "minlv": 66,
+                    "monsNo": 65693
+                },
+                {
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
+                }
+            ],
             "gbaEme": [
                 {
                     "maxlv": 66,
@@ -26958,8 +26988,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -26968,8 +26998,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -26983,23 +27013,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -27008,8 +27038,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -27020,8 +27050,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -27032,8 +27062,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -27044,8 +27074,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -27058,17 +27088,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -27090,9 +27120,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -27107,14 +27137,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -27124,14 +27154,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -27141,14 +27171,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -27158,14 +27188,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -27291,8 +27321,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -27301,8 +27331,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -27316,23 +27346,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -27341,8 +27371,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -27353,8 +27383,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -27365,8 +27395,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -27377,8 +27407,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -27391,17 +27421,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -27423,9 +27453,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -27440,14 +27470,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -27457,14 +27487,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -27474,14 +27504,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -27491,14 +27521,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -27624,8 +27654,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -27634,8 +27664,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -27649,23 +27679,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -27674,8 +27704,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -27686,8 +27716,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -27698,8 +27728,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -27710,8 +27740,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -27724,17 +27754,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -27756,9 +27786,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -27773,14 +27803,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -27790,14 +27820,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -27807,14 +27837,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -27824,14 +27854,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -27957,8 +27987,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -27967,8 +27997,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -27982,23 +28012,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -28007,8 +28037,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -28019,8 +28049,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -28031,8 +28061,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -28043,8 +28073,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -28057,17 +28087,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -28089,9 +28119,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -28106,14 +28136,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -28123,14 +28153,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -28140,14 +28170,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -28157,14 +28187,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -28290,8 +28320,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -28300,8 +28330,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -28315,23 +28345,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -28340,8 +28370,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -28352,8 +28382,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -28364,8 +28394,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -28376,8 +28406,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -28390,17 +28420,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -28422,9 +28452,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -28439,14 +28469,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -28456,14 +28486,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -28473,14 +28503,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -28490,14 +28520,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -28623,8 +28653,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -28633,8 +28663,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -28648,23 +28678,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -28673,8 +28703,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -28685,8 +28715,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -28697,8 +28727,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -28709,8 +28739,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -28723,17 +28753,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -28755,9 +28785,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -28772,14 +28802,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -28789,14 +28819,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -28806,14 +28836,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -28823,14 +28853,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -28956,8 +28986,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -28966,8 +28996,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -28981,23 +29011,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -29006,8 +29036,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -29018,8 +29048,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -29030,8 +29060,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -29042,8 +29072,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -29056,17 +29086,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -29088,9 +29118,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -29105,14 +29135,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -29122,14 +29152,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -29139,14 +29169,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -29156,14 +29186,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -29289,8 +29319,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -29299,8 +29329,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -29314,23 +29344,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -29339,8 +29369,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -29351,8 +29381,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -29363,8 +29393,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -29375,8 +29405,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -29389,17 +29419,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -29421,9 +29451,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -29438,14 +29468,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -29455,14 +29485,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -29472,14 +29502,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -29489,14 +29519,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -29622,8 +29652,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -29632,8 +29662,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -29647,23 +29677,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -29672,8 +29702,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -29684,8 +29714,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -29696,8 +29726,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -29708,8 +29738,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -29722,17 +29752,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -29754,9 +29784,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -29771,14 +29801,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -29788,14 +29818,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -29805,14 +29835,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -29822,14 +29852,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -29955,8 +29985,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -29965,8 +29995,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -29980,23 +30010,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -30005,8 +30035,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -30017,8 +30047,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -30029,8 +30059,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -30041,8 +30071,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -30055,17 +30085,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -30087,9 +30117,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -30104,14 +30134,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -30121,14 +30151,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -30138,14 +30168,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -30155,14 +30185,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -30288,8 +30318,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -30298,8 +30328,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -30313,23 +30343,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -30338,8 +30368,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -30350,8 +30380,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -30362,8 +30392,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -30374,8 +30404,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -30388,17 +30418,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -30420,9 +30450,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -30437,14 +30467,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -30454,14 +30484,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -30471,14 +30501,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -30488,14 +30518,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -30621,8 +30651,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -30631,8 +30661,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -30646,23 +30676,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -30671,8 +30701,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -30683,8 +30713,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -30695,8 +30725,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -30707,8 +30737,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -30721,17 +30751,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -30753,9 +30783,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -30770,14 +30800,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -30787,14 +30817,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -30804,14 +30834,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -30821,14 +30851,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -30954,8 +30984,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -30964,8 +30994,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -30979,23 +31009,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -31004,8 +31034,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -31016,8 +31046,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -31028,8 +31058,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -31040,8 +31070,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -31054,17 +31084,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -31086,9 +31116,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -31103,14 +31133,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -31120,14 +31150,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -31137,14 +31167,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -31154,14 +31184,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -31287,8 +31317,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -31297,8 +31327,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -31312,23 +31342,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -31337,8 +31367,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -31349,8 +31379,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -31361,8 +31391,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -31373,8 +31403,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -31387,17 +31417,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -31419,9 +31449,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -31436,14 +31466,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -31453,14 +31483,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -31470,14 +31500,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -31487,14 +31517,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -31620,8 +31650,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -31630,8 +31660,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -31645,23 +31675,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -31670,8 +31700,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -31682,8 +31712,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -31694,8 +31724,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -31706,8 +31736,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -31720,17 +31750,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -31752,9 +31782,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -31769,14 +31799,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -31786,14 +31816,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -31803,14 +31833,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -31820,14 +31850,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -31953,8 +31983,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -31963,8 +31993,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -31978,23 +32008,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -32003,8 +32033,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -32015,8 +32045,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -32027,8 +32057,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -32039,8 +32069,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -32053,17 +32083,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -32085,9 +32115,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -32102,14 +32132,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -32119,14 +32149,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -32136,14 +32166,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -32153,14 +32183,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -32286,8 +32316,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -32296,8 +32326,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -32311,23 +32341,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -32336,8 +32366,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -32348,8 +32378,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -32360,8 +32390,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -32372,8 +32402,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -32386,17 +32416,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -32418,9 +32448,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -32435,14 +32465,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -32452,14 +32482,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -32469,14 +32499,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -32486,14 +32516,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -32619,8 +32649,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -32629,8 +32659,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -32644,23 +32674,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -32669,8 +32699,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -32681,8 +32711,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -32693,8 +32723,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -32705,8 +32735,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -32719,17 +32749,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -32751,9 +32781,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -32768,14 +32798,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -32785,14 +32815,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -32802,14 +32832,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -32819,14 +32849,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -32952,8 +32982,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -32962,8 +32992,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -32977,23 +33007,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -33002,8 +33032,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -33014,8 +33044,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -33026,8 +33056,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -33038,8 +33068,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -33052,17 +33082,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -33084,9 +33114,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -33101,14 +33131,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -33118,14 +33148,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -33135,14 +33165,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -33152,14 +33182,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -33285,8 +33315,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -33295,8 +33325,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -33310,23 +33340,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -33335,8 +33365,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -33347,8 +33377,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -33359,8 +33389,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -33371,8 +33401,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -33385,17 +33415,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -33417,9 +33447,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -33434,14 +33464,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -33451,14 +33481,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -33468,14 +33498,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -33485,14 +33515,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -33618,8 +33648,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -33628,8 +33658,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -33643,23 +33673,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -33668,8 +33698,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -33680,8 +33710,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -33692,8 +33722,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -33704,8 +33734,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -33718,17 +33748,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -33750,9 +33780,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -33767,14 +33797,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -33784,14 +33814,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -33801,14 +33831,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -33818,14 +33848,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -33951,8 +33981,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -33961,8 +33991,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -33976,23 +34006,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -34001,8 +34031,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -34013,8 +34043,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -34025,8 +34055,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -34037,8 +34067,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -34051,17 +34081,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -34083,9 +34113,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -34100,14 +34130,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -34117,14 +34147,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -34134,14 +34164,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -34151,14 +34181,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -34284,8 +34314,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -34294,8 +34324,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -34309,23 +34339,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -34334,8 +34364,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -34346,8 +34376,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -34358,8 +34388,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -34370,8 +34400,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -34384,17 +34414,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -34416,9 +34446,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -34433,14 +34463,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -34450,14 +34480,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -34467,14 +34497,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -34484,14 +34514,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -34617,8 +34647,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -34627,8 +34657,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -34642,23 +34672,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -34667,8 +34697,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -34679,8 +34709,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -34691,8 +34721,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -34703,8 +34733,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -34717,17 +34747,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -34749,9 +34779,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -34766,14 +34796,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -34783,14 +34813,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -34800,14 +34830,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -34817,14 +34847,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -34950,8 +34980,8 @@
             "encRate_gr": 15,
             "ground_mons": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -34960,8 +34990,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -34975,23 +35005,23 @@
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -35000,8 +35030,8 @@
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 436
                 },
                 {
@@ -35012,8 +35042,8 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 42
                 },
                 {
@@ -35024,8 +35054,8 @@
             ],
             "day": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -35036,8 +35066,8 @@
             ],
             "night": [
                 {
-                    "maxlv": 55,
-                    "minlv": 55,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 93
                 },
                 {
@@ -35050,17 +35080,17 @@
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 93
-                },
-                {
-                    "maxlv": 55,
-                    "minlv": 55,
                     "monsNo": 437
                 },
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
+                },
+                {
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 437
                 },
                 {
                     "maxlv": 56,
@@ -35082,9 +35112,9 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 338
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
@@ -35099,14 +35129,14 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
+                    "maxlv": 56,
+                    "minlv": 56,
                     "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 337
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -35116,14 +35146,14 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -35133,14 +35163,14 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -35150,14 +35180,14 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 54,
-                    "minlv": 54,
-                    "monsNo": 436
+                    "maxlv": 56,
+                    "minlv": 56,
+                    "monsNo": 337
                 },
                 {
                     "maxlv": 56,
                     "minlv": 56,
-                    "monsNo": 437
+                    "monsNo": 338
                 },
                 {
                     "maxlv": 0,
@@ -35284,22 +35314,22 @@
             "ground_mons": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 47,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
@@ -35309,17 +35339,17 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 124
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 362
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 478
                 },
                 {
@@ -35329,7 +35359,7 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 42
                 },
                 {
@@ -35339,61 +35369,61 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 42
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 50,
-                    "minlv": 47,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "day": [
                 {
                     "maxlv": 50,
-                    "minlv": 47,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "night": [
                 {
                     "maxlv": 50,
-                    "minlv": 47,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 50,
-                    "minlv": 49,
-                    "monsNo": 208
-                },
-                {
-                    "maxlv": 50,
-                    "minlv": 49,
-                    "monsNo": 124
+                    "minlv": 50,
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 461
+                    "monsNo": 42
+                },
+                {
+                    "maxlv": 50,
+                    "minlv": 50,
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
@@ -35617,22 +35647,22 @@
             "ground_mons": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
@@ -35642,17 +35672,17 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 124
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 362
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 478
                 },
                 {
@@ -35662,7 +35692,7 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 42
                 },
                 {
@@ -35672,61 +35702,61 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 42
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "day": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "night": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 50,
-                    "minlv": 49,
-                    "monsNo": 208
-                },
-                {
-                    "maxlv": 50,
-                    "minlv": 49,
-                    "monsNo": 124
+                    "minlv": 50,
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 461
+                    "monsNo": 42
+                },
+                {
+                    "maxlv": 50,
+                    "minlv": 50,
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
@@ -35950,22 +35980,22 @@
             "ground_mons": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
@@ -35975,17 +36005,17 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 124
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 362
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 478
                 },
                 {
@@ -35995,7 +36025,7 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 42
                 },
                 {
@@ -36005,61 +36035,61 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 42
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "day": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "night": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 50,
-                    "minlv": 49,
-                    "monsNo": 208
-                },
-                {
-                    "maxlv": 50,
-                    "minlv": 49,
-                    "monsNo": 124
+                    "minlv": 50,
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 461
+                    "monsNo": 42
+                },
+                {
+                    "maxlv": 50,
+                    "minlv": 50,
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
@@ -36283,22 +36313,22 @@
             "ground_mons": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
@@ -36308,17 +36338,17 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 124
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 362
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 478
                 },
                 {
@@ -36328,7 +36358,7 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 42
                 },
                 {
@@ -36338,61 +36368,61 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 42
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "day": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "night": [
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 50,
-                    "minlv": 49,
-                    "monsNo": 208
-                },
-                {
-                    "maxlv": 50,
-                    "minlv": 49,
-                    "monsNo": 124
+                    "minlv": 50,
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 461
+                    "monsNo": 42
+                },
+                {
+                    "maxlv": 50,
+                    "minlv": 50,
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
@@ -36616,22 +36646,22 @@
             "ground_mons": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
@@ -36641,17 +36671,17 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 124
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 362
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 478
                 },
                 {
@@ -36661,7 +36691,7 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 42
                 },
                 {
@@ -36671,61 +36701,61 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 42
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "day": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "night": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 50,
-                    "minlv": 49,
-                    "monsNo": 208
-                },
-                {
-                    "maxlv": 50,
-                    "minlv": 49,
-                    "monsNo": 124
+                    "minlv": 50,
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 461
+                    "monsNo": 42
+                },
+                {
+                    "maxlv": 50,
+                    "minlv": 50,
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
@@ -36949,22 +36979,22 @@
             "ground_mons": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
@@ -36974,17 +37004,17 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 124
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 362
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 478
                 },
                 {
@@ -36994,7 +37024,7 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 42
                 },
                 {
@@ -37004,61 +37034,61 @@
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 42
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "day": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "night": [
                 {
                     "maxlv": 50,
-                    "minlv": 48,
+                    "minlv": 50,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 50,
-                    "minlv": 49,
+                    "minlv": 50,
                     "monsNo": 215
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 50,
-                    "minlv": 49,
-                    "monsNo": 208
-                },
-                {
-                    "maxlv": 50,
-                    "minlv": 49,
-                    "monsNo": 124
+                    "minlv": 50,
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
                     "minlv": 50,
-                    "monsNo": 461
+                    "monsNo": 42
+                },
+                {
+                    "maxlv": 50,
+                    "minlv": 50,
+                    "monsNo": 42
                 },
                 {
                     "maxlv": 50,
@@ -37282,27 +37312,27 @@
             "ground_mons": [
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 41
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 20,
+                    "minlv": 22,
                     "monsNo": 443
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 343
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 27
                 },
                 {
@@ -37322,12 +37352,12 @@
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 443
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 443
                 },
                 {
@@ -37344,49 +37374,49 @@
             "tairyo": [
                 {
                     "maxlv": 22,
-                    "minlv": 20,
+                    "minlv": 22,
                     "monsNo": 443
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 343
                 }
             ],
             "day": [
                 {
                     "maxlv": 22,
-                    "minlv": 20,
+                    "minlv": 22,
                     "monsNo": 443
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 343
                 }
             ],
             "night": [
                 {
                     "maxlv": 22,
-                    "minlv": 20,
+                    "minlv": 22,
                     "monsNo": 443
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 343
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 22,
-                    "minlv": 21,
-                    "monsNo": 27
+                    "minlv": 22,
+                    "monsNo": 443
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
-                    "monsNo": 95
+                    "minlv": 22,
+                    "monsNo": 443
                 },
                 {
                     "maxlv": 22,
@@ -37615,27 +37645,27 @@
             "ground_mons": [
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 41
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 74
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 20,
+                    "minlv": 22,
                     "monsNo": 443
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 343
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 27
                 },
                 {
@@ -37655,12 +37685,12 @@
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 443
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 443
                 },
                 {
@@ -37677,49 +37707,49 @@
             "tairyo": [
                 {
                     "maxlv": 22,
-                    "minlv": 20,
+                    "minlv": 22,
                     "monsNo": 443
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 343
                 }
             ],
             "day": [
                 {
                     "maxlv": 22,
-                    "minlv": 20,
+                    "minlv": 22,
                     "monsNo": 443
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 343
                 }
             ],
             "night": [
                 {
                     "maxlv": 22,
-                    "minlv": 20,
+                    "minlv": 22,
                     "monsNo": 443
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 343
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 22,
-                    "minlv": 21,
-                    "monsNo": 27
+                    "minlv": 22,
+                    "monsNo": 443
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
-                    "monsNo": 95
+                    "minlv": 22,
+                    "monsNo": 443
                 },
                 {
                     "maxlv": 22,
@@ -37948,47 +37978,47 @@
             "ground_mons": [
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 293
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 449
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 328
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 31,
+                    "minlv": 32,
                     "monsNo": 294
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 132
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 30,
+                    "minlv": 32,
                     "monsNo": 449
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 328
                 },
                 {
@@ -37998,7 +38028,7 @@
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 328
                 },
                 {
@@ -38010,54 +38040,54 @@
             "tairyo": [
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 449
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 328
                 }
             ],
             "day": [
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 449
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 328
                 }
             ],
             "night": [
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 449
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 328
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 32,
-                    "minlv": 31,
-                    "monsNo": 294
-                },
-                {
-                    "maxlv": 32,
-                    "minlv": 31,
-                    "monsNo": 132
+                    "minlv": 32,
+                    "monsNo": 51
                 },
                 {
                     "maxlv": 32,
                     "minlv": 32,
-                    "monsNo": 328
+                    "monsNo": 51
+                },
+                {
+                    "maxlv": 32,
+                    "minlv": 32,
+                    "monsNo": 51
                 },
                 {
                     "maxlv": 32,
@@ -38281,47 +38311,47 @@
             "ground_mons": [
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 293
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 449
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 328
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 31,
+                    "minlv": 32,
                     "monsNo": 294
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 132
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 30,
+                    "minlv": 32,
                     "monsNo": 449
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 328
                 },
                 {
@@ -38331,7 +38361,7 @@
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 328
                 },
                 {
@@ -38343,54 +38373,54 @@
             "tairyo": [
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 449
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 328
                 }
             ],
             "day": [
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 449
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 328
                 }
             ],
             "night": [
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 449
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 328
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 32,
-                    "minlv": 31,
-                    "monsNo": 294
-                },
-                {
-                    "maxlv": 32,
-                    "minlv": 31,
-                    "monsNo": 132
+                    "minlv": 32,
+                    "monsNo": 51
                 },
                 {
                     "maxlv": 32,
                     "minlv": 32,
-                    "monsNo": 328
+                    "monsNo": 51
+                },
+                {
+                    "maxlv": 32,
+                    "minlv": 32,
+                    "monsNo": 51
                 },
                 {
                     "maxlv": 32,
@@ -38614,47 +38644,47 @@
             "ground_mons": [
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 293
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 449
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 328
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 31,
+                    "minlv": 32,
                     "monsNo": 294
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 132
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 30,
+                    "minlv": 32,
                     "monsNo": 449
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 50
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 328
                 },
                 {
@@ -38664,7 +38694,7 @@
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 328
                 },
                 {
@@ -38676,54 +38706,54 @@
             "tairyo": [
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 449
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 328
                 }
             ],
             "day": [
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 449
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 328
                 }
             ],
             "night": [
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 449
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 328
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 32,
-                    "minlv": 31,
-                    "monsNo": 294
-                },
-                {
-                    "maxlv": 32,
-                    "minlv": 31,
-                    "monsNo": 132
+                    "minlv": 32,
+                    "monsNo": 51
                 },
                 {
                     "maxlv": 32,
                     "minlv": 32,
-                    "monsNo": 328
+                    "monsNo": 51
+                },
+                {
+                    "maxlv": 32,
+                    "minlv": 32,
+                    "monsNo": 51
                 },
                 {
                     "maxlv": 32,
@@ -38947,7 +38977,7 @@
             "ground_mons": [
                 {
                     "maxlv": 26,
-                    "minlv": 24,
+                    "minlv": 26,
                     "monsNo": 172
                 },
                 {
@@ -38957,8 +38987,8 @@
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 24,
-                    "monsNo": 173
+                    "minlv": 26,
+                    "monsNo": 133
                 },
                 {
                     "maxlv": 26,
@@ -38967,27 +38997,17 @@
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 24,
+                    "minlv": 26,
                     "monsNo": 175
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 24,
+                    "minlv": 26,
                     "monsNo": 174
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 24,
-                    "monsNo": 440
-                },
-                {
-                    "maxlv": 26,
-                    "minlv": 25,
-                    "monsNo": 133
-                },
-                {
-                    "maxlv": 26,
-                    "minlv": 24,
+                    "minlv": 26,
                     "monsNo": 440
                 },
                 {
@@ -38997,7 +39017,17 @@
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 24,
+                    "minlv": 26,
+                    "monsNo": 440
+                },
+                {
+                    "maxlv": 26,
+                    "minlv": 26,
+                    "monsNo": 133
+                },
+                {
+                    "maxlv": 26,
+                    "minlv": 26,
                     "monsNo": 440
                 },
                 {
@@ -39009,7 +39039,7 @@
             "tairyo": [
                 {
                     "maxlv": 26,
-                    "minlv": 24,
+                    "minlv": 26,
                     "monsNo": 173
                 },
                 {
@@ -39021,8 +39051,8 @@
             "day": [
                 {
                     "maxlv": 26,
-                    "minlv": 24,
-                    "monsNo": 173
+                    "minlv": 26,
+                    "monsNo": 133
                 },
                 {
                     "maxlv": 26,
@@ -39033,34 +39063,34 @@
             "night": [
                 {
                     "maxlv": 26,
-                    "minlv": 24,
+                    "minlv": 26,
                     "monsNo": 173
                 },
                 {
                     "maxlv": 26,
                     "minlv": 26,
-                    "monsNo": 137
+                    "monsNo": 173
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 351
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 351
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 351
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 351
                 }
             ],
@@ -39421,8 +39451,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 864
                 }
             ],
@@ -39438,8 +39468,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 864
                 }
             ],
@@ -39455,8 +39485,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 864
                 }
             ],
@@ -39472,8 +39502,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 864
                 }
             ],
@@ -39490,35 +39520,35 @@
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 45,
                     "monsNo": 864
                 }
             ],
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 40,
-                    "minlv": 30,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 278
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 30,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 72
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 279
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 73
                 }
             ],
@@ -39613,120 +39643,120 @@
             "ground_mons": [
                 {
                     "maxlv": 45,
-                    "minlv": 41,
+                    "minlv": 45,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 41,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 303
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 302
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 299
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 112
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 208
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 112
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 208
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 45,
-                    "minlv": 41,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "day": [
                 {
                     "maxlv": 45,
-                    "minlv": 41,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "night": [
                 {
                     "maxlv": 45,
-                    "minlv": 41,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 45,
-                    "minlv": 42,
-                    "monsNo": 302
+                    "minlv": 45,
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
-                    "monsNo": 299
+                    "minlv": 45,
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
-                    "monsNo": 112
+                    "minlv": 45,
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 208
                 }
             ],
@@ -39744,87 +39774,87 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaEme": [
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaFire": [
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "encRate_wat": 0,
@@ -39946,120 +39976,120 @@
             "ground_mons": [
                 {
                     "maxlv": 45,
-                    "minlv": 41,
+                    "minlv": 45,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 41,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 303
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 302
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 299
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 112
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 208
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 112
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 208
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 45,
-                    "minlv": 41,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "day": [
                 {
                     "maxlv": 45,
-                    "minlv": 41,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "night": [
                 {
                     "maxlv": 45,
-                    "minlv": 41,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 45,
-                    "minlv": 43,
-                    "monsNo": 302
+                    "minlv": 45,
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
-                    "monsNo": 299
+                    "minlv": 45,
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
-                    "monsNo": 112
+                    "minlv": 45,
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 208
                 }
             ],
@@ -40077,87 +40107,87 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaEme": [
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaFire": [
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "encRate_wat": 0,
@@ -40279,120 +40309,120 @@
             "ground_mons": [
                 {
                     "maxlv": 45,
-                    "minlv": 41,
+                    "minlv": 45,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 41,
+                    "minlv": 45,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 41,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 303
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 302
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 299
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 112
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 208
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 112
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 208
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 45,
-                    "minlv": 42,
-                    "monsNo": 303
+                    "minlv": 45,
+                    "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 41,
-                    "monsNo": 305
+                    "minlv": 45,
+                    "monsNo": 303
                 }
             ],
             "day": [
                 {
                     "maxlv": 45,
-                    "minlv": 41,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "night": [
                 {
                     "maxlv": 45,
-                    "minlv": 41,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 45,
-                    "minlv": 42,
-                    "monsNo": 302
+                    "minlv": 45,
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 42,
-                    "monsNo": 299
+                    "minlv": 45,
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
-                    "monsNo": 112
+                    "minlv": 45,
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 208
                 }
             ],
@@ -40410,87 +40440,87 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaEme": [
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaFire": [
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 43,
-                    "minlv": 43,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65611
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "encRate_wat": 0,
@@ -40612,42 +40642,42 @@
             "ground_mons": [
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 303
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 302
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 299
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
@@ -40674,58 +40704,58 @@
             "tairyo": [
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "day": [
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "night": [
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 45,
-                    "minlv": 43,
-                    "monsNo": 302
+                    "minlv": 45,
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
-                    "monsNo": 299
+                    "minlv": 45,
+                    "monsNo": 208
                 },
                 {
-                    "maxlv": 44,
-                    "minlv": 44,
-                    "monsNo": 112
+                    "maxlv": 45,
+                    "minlv": 45,
+                    "monsNo": 208
                 },
                 {
-                    "maxlv": 44,
-                    "minlv": 44,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 208
                 }
             ],
@@ -40753,9 +40783,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaSapp": [
@@ -40770,9 +40800,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaEme": [
@@ -40787,9 +40817,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaFire": [
@@ -40804,9 +40834,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaLeaf": [
@@ -40822,8 +40852,8 @@
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "encRate_wat": 0,
@@ -40945,42 +40975,42 @@
             "ground_mons": [
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 303
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 302
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 299
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
@@ -41007,54 +41037,54 @@
             "tairyo": [
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "day": [
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "night": [
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 45,
-                    "minlv": 44,
-                    "monsNo": 302
-                },
-                {
-                    "maxlv": 45,
-                    "minlv": 44,
-                    "monsNo": 299
+                    "minlv": 45,
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 112
+                    "monsNo": 208
+                },
+                {
+                    "maxlv": 45,
+                    "minlv": 45,
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
@@ -41086,9 +41116,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaSapp": [
@@ -41103,9 +41133,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaEme": [
@@ -41120,9 +41150,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaFire": [
@@ -41137,9 +41167,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaLeaf": [
@@ -41154,9 +41184,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 40,
+                    "monsNo": 0
                 }
             ],
             "encRate_wat": 0,
@@ -41278,42 +41308,42 @@
             "ground_mons": [
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 303
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 302
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 299
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
@@ -41340,54 +41370,54 @@
             "tairyo": [
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "day": [
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "night": [
                 {
                     "maxlv": 45,
-                    "minlv": 43,
+                    "minlv": 45,
                     "monsNo": 305
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 44,
+                    "minlv": 45,
                     "monsNo": 303
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 45,
-                    "minlv": 44,
-                    "monsNo": 302
-                },
-                {
-                    "maxlv": 45,
-                    "minlv": 44,
-                    "monsNo": 299
+                    "minlv": 45,
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
                     "minlv": 45,
-                    "monsNo": 112
+                    "monsNo": 208
+                },
+                {
+                    "maxlv": 45,
+                    "minlv": 45,
+                    "monsNo": 208
                 },
                 {
                     "maxlv": 45,
@@ -41419,9 +41449,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaSapp": [
@@ -41436,9 +41466,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaEme": [
@@ -41453,9 +41483,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaFire": [
@@ -41470,9 +41500,9 @@
                     "monsNo": 65611
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "maxlv": 0,
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "gbaLeaf": [
@@ -41488,8 +41518,8 @@
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
-                    "monsNo": 864
+                    "minlv": 0,
+                    "monsNo": 0
                 }
             ],
             "encRate_wat": 0,
@@ -41611,42 +41641,42 @@
             "ground_mons": [
                 {
                     "maxlv": 18,
-                    "minlv": 15,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 15,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
@@ -41673,54 +41703,54 @@
             "tairyo": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "day": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "night": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 92
-                },
-                {
-                    "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 19
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
+                },
+                {
+                    "maxlv": 18,
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -41943,43 +41973,43 @@
             "encRate_gr": 10,
             "ground_mons": [
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 18,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
-                    "maxlv": 15,
-                    "minlv": 15,
+                    "maxlv": 18,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 18,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 18,
+                    "minlv": 18,
                     "monsNo": 353
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 18,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 18,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 18,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
+                    "maxlv": 18,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
@@ -42005,55 +42035,55 @@
             ],
             "tairyo": [
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 18,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 18,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "day": [
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 18,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 18,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "night": [
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 18,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
-                    "maxlv": 16,
-                    "minlv": 16,
+                    "maxlv": 18,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 17,
-                    "minlv": 17,
-                    "monsNo": 92
-                },
-                {
-                    "maxlv": 17,
-                    "minlv": 17,
-                    "monsNo": 19
+                    "maxlv": 18,
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
+                },
+                {
+                    "maxlv": 18,
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -42277,42 +42307,42 @@
             "ground_mons": [
                 {
                     "maxlv": 18,
-                    "minlv": 15,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 15,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
@@ -42339,54 +42369,54 @@
             "tairyo": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "day": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "night": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 92
-                },
-                {
-                    "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 19
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
+                },
+                {
+                    "maxlv": 18,
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -42610,42 +42640,42 @@
             "ground_mons": [
                 {
                     "maxlv": 18,
-                    "minlv": 15,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 15,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
@@ -42672,54 +42702,54 @@
             "tairyo": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "day": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "night": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 92
-                },
-                {
-                    "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 19
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
+                },
+                {
+                    "maxlv": 18,
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -42943,42 +42973,42 @@
             "ground_mons": [
                 {
                     "maxlv": 18,
-                    "minlv": 15,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 15,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
@@ -43005,54 +43035,54 @@
             "tairyo": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "day": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "night": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 92
-                },
-                {
-                    "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 19
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
+                },
+                {
+                    "maxlv": 18,
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -43276,42 +43306,42 @@
             "ground_mons": [
                 {
                     "maxlv": 18,
-                    "minlv": 15,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 15,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
@@ -43338,54 +43368,54 @@
             "tairyo": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "day": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "night": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 92
-                },
-                {
-                    "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 19
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
+                },
+                {
+                    "maxlv": 18,
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -43609,42 +43639,42 @@
             "ground_mons": [
                 {
                     "maxlv": 18,
-                    "minlv": 15,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 15,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
@@ -43671,54 +43701,54 @@
             "tairyo": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "day": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "night": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 92
-                },
-                {
-                    "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 19
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
+                },
+                {
+                    "maxlv": 18,
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -43942,42 +43972,42 @@
             "ground_mons": [
                 {
                     "maxlv": 18,
-                    "minlv": 15,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 15,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
@@ -44004,54 +44034,54 @@
             "tairyo": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "day": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "night": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 92
-                },
-                {
-                    "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 19
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
+                },
+                {
+                    "maxlv": 18,
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -44275,42 +44305,42 @@
             "ground_mons": [
                 {
                     "maxlv": 18,
-                    "minlv": 15,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 15,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 92
                 },
                 {
@@ -44337,54 +44367,54 @@
             "tairyo": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "day": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "night": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 353
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 92
-                },
-                {
-                    "maxlv": 18,
-                    "minlv": 17,
-                    "monsNo": 19
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
                     "minlv": 18,
-                    "monsNo": 20
+                    "monsNo": 93
+                },
+                {
+                    "maxlv": 18,
+                    "minlv": 18,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 18,
@@ -44608,17 +44638,17 @@
             "ground_mons": [
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 396
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 399
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 283
                 },
                 {
@@ -44638,7 +44668,7 @@
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 278
                 },
                 {
@@ -44670,7 +44700,7 @@
             "tairyo": [
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 283
                 },
                 {
@@ -44682,7 +44712,7 @@
             "day": [
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 283
                 },
                 {
@@ -44694,7 +44724,7 @@
             "night": [
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 283
                 },
                 {
@@ -44706,12 +44736,12 @@
             "swayGrass": [
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 360
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 360
                 },
                 {
@@ -44749,7 +44779,7 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -44766,7 +44796,7 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -44783,7 +44813,7 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -44800,7 +44830,7 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -44817,7 +44847,7 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -44826,27 +44856,27 @@
             "water_mons": [
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 283
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 283
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 30,
+                    "minlv": 40,
                     "monsNo": 284
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 30,
+                    "minlv": 40,
                     "monsNo": 284
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 30,
+                    "minlv": 40,
                     "monsNo": 284
                 }
             ],
@@ -44941,17 +44971,17 @@
             "ground_mons": [
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 396
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 399
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 283
                 },
                 {
@@ -44971,7 +45001,7 @@
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 278
                 },
                 {
@@ -45003,7 +45033,7 @@
             "tairyo": [
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 283
                 },
                 {
@@ -45015,7 +45045,7 @@
             "day": [
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 283
                 },
                 {
@@ -45027,7 +45057,7 @@
             "night": [
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 283
                 },
                 {
@@ -45039,12 +45069,12 @@
             "swayGrass": [
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 360
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 360
                 },
                 {
@@ -45082,7 +45112,7 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -45099,7 +45129,7 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -45116,7 +45146,7 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -45133,7 +45163,7 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -45150,7 +45180,7 @@
                     "monsNo": 65588
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -45159,27 +45189,27 @@
             "water_mons": [
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 283
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 283
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 30,
+                    "minlv": 40,
                     "monsNo": 284
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 30,
+                    "minlv": 40,
                     "monsNo": 284
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 30,
+                    "minlv": 40,
                     "monsNo": 284
                 }
             ],
@@ -45273,13 +45303,13 @@
             "encRate_gr": 30,
             "ground_mons": [
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 397
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 400
                 },
                 {
@@ -45288,13 +45318,13 @@
                     "monsNo": 284
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 284
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 108
                 },
                 {
@@ -45340,8 +45370,8 @@
                     "monsNo": 284
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 284
                 }
             ],
@@ -45371,13 +45401,13 @@
             ],
             "swayGrass": [
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 202
                 },
                 {
-                    "maxlv": 53,
-                    "minlv": 53,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 202
                 },
                 {
@@ -45415,8 +45445,8 @@
                     "monsNo": 865
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 131152
                 }
             ],
@@ -45432,8 +45462,8 @@
                     "monsNo": 865
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 131152
                 }
             ],
@@ -45449,8 +45479,8 @@
                     "monsNo": 865
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 131152
                 }
             ],
@@ -45466,8 +45496,8 @@
                     "monsNo": 865
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 131152
                 }
             ],
@@ -45483,36 +45513,36 @@
                     "monsNo": 865
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 131152
                 }
             ],
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 45,
-                    "minlv": 35,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 283
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 35,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 283
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 45,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 284
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 45,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 284
                 },
                 {
-                    "maxlv": 55,
-                    "minlv": 45,
+                    "maxlv": 54,
+                    "minlv": 54,
                     "monsNo": 284
                 }
             ],
@@ -45607,32 +45637,32 @@
             "ground_mons": [
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 460
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 124
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 221
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 362
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 215
                 },
                 {
@@ -45647,70 +45677,70 @@
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 221
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 221
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 221
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 221
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 51,
-                    "minlv": 49,
-                    "monsNo": 221
+                    "minlv": 51,
+                    "monsNo": 124
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 49,
-                    "monsNo": 124
+                    "minlv": 51,
+                    "monsNo": 221
                 }
             ],
             "day": [
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 124
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 221
                 }
             ],
             "night": [
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 124
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 49,
+                    "minlv": 51,
                     "monsNo": 221
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 202
                 },
                 {
                     "maxlv": 51,
-                    "minlv": 50,
+                    "minlv": 51,
                     "monsNo": 202
                 },
                 {
@@ -45748,8 +45778,8 @@
                     "monsNo": 866
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 51,
+                    "minlv": 51,
                     "monsNo": 864
                 }
             ],
@@ -45765,8 +45795,8 @@
                     "monsNo": 866
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 51,
+                    "minlv": 51,
                     "monsNo": 864
                 }
             ],
@@ -45782,8 +45812,8 @@
                     "monsNo": 866
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 51,
+                    "minlv": 51,
                     "monsNo": 864
                 }
             ],
@@ -45799,8 +45829,8 @@
                     "monsNo": 866
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 51,
+                    "minlv": 51,
                     "monsNo": 864
                 }
             ],
@@ -45819,28 +45849,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 50,
-                    "minlv": 45,
+                    "maxlv": 51,
+                    "minlv": 51,
                     "monsNo": 364
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 45,
+                    "maxlv": 51,
+                    "minlv": 51,
                     "monsNo": 87
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 45,
+                    "maxlv": 51,
+                    "minlv": 51,
                     "monsNo": 131
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 45,
+                    "maxlv": 51,
+                    "minlv": 51,
                     "monsNo": 87
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 45,
+                    "maxlv": 51,
+                    "minlv": 51,
                     "monsNo": 87
                 }
             ],
@@ -45935,7 +45965,7 @@
             "ground_mons": [
                 {
                     "maxlv": 33,
-                    "minlv": 31,
+                    "minlv": 33,
                     "monsNo": 203
                 },
                 {
@@ -45945,12 +45975,12 @@
                 },
                 {
                     "maxlv": 33,
-                    "minlv": 31,
+                    "minlv": 33,
                     "monsNo": 33
                 },
                 {
                     "maxlv": 33,
-                    "minlv": 31,
+                    "minlv": 33,
                     "monsNo": 30
                 },
                 {
@@ -45965,22 +45995,22 @@
                 },
                 {
                     "maxlv": 33,
-                    "minlv": 32,
+                    "minlv": 33,
                     "monsNo": 33
                 },
                 {
                     "maxlv": 33,
-                    "minlv": 32,
+                    "minlv": 33,
                     "monsNo": 30
                 },
                 {
                     "maxlv": 33,
-                    "minlv": 32,
+                    "minlv": 33,
                     "monsNo": 33
                 },
                 {
                     "maxlv": 33,
-                    "minlv": 32,
+                    "minlv": 33,
                     "monsNo": 30
                 },
                 {
@@ -45997,48 +46027,48 @@
             "tairyo": [
                 {
                     "maxlv": 33,
-                    "minlv": 31,
+                    "minlv": 33,
                     "monsNo": 30
                 },
                 {
                     "maxlv": 33,
-                    "minlv": 31,
-                    "monsNo": 34
+                    "minlv": 33,
+                    "monsNo": 33
                 }
             ],
             "day": [
                 {
                     "maxlv": 33,
-                    "minlv": 31,
+                    "minlv": 33,
                     "monsNo": 33
                 },
                 {
                     "maxlv": 33,
-                    "minlv": 31,
+                    "minlv": 33,
                     "monsNo": 30
                 }
             ],
             "night": [
                 {
                     "maxlv": 33,
-                    "minlv": 31,
+                    "minlv": 33,
                     "monsNo": 33
                 },
                 {
                     "maxlv": 33,
-                    "minlv": 31,
+                    "minlv": 33,
                     "monsNo": 30
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 33,
-                    "minlv": 32,
+                    "minlv": 33,
                     "monsNo": 49
                 },
                 {
                     "maxlv": 33,
-                    "minlv": 32,
+                    "minlv": 33,
                     "monsNo": 49
                 },
                 {
@@ -46268,12 +46298,12 @@
             "ground_mons": [
                 {
                     "maxlv": 49,
-                    "minlv": 47,
+                    "minlv": 49,
                     "monsNo": 221
                 },
                 {
                     "maxlv": 49,
-                    "minlv": 45,
+                    "minlv": 49,
                     "monsNo": 361
                 },
                 {
@@ -46283,32 +46313,32 @@
                 },
                 {
                     "maxlv": 49,
-                    "minlv": 48,
+                    "minlv": 49,
                     "monsNo": 362
                 },
                 {
                     "maxlv": 49,
-                    "minlv": 48,
+                    "minlv": 49,
                     "monsNo": 124
                 },
                 {
                     "maxlv": 49,
-                    "minlv": 48,
+                    "minlv": 49,
                     "monsNo": 225
                 },
                 {
                     "maxlv": 49,
-                    "minlv": 47,
+                    "minlv": 49,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 49,
-                    "minlv": 48,
+                    "minlv": 49,
                     "monsNo": 221
                 },
                 {
                     "maxlv": 49,
-                    "minlv": 48,
+                    "minlv": 49,
                     "monsNo": 215
                 },
                 {
@@ -46335,7 +46365,7 @@
                 },
                 {
                     "maxlv": 49,
-                    "minlv": 48,
+                    "minlv": 49,
                     "monsNo": 362
                 }
             ],
@@ -46347,7 +46377,7 @@
                 },
                 {
                     "maxlv": 49,
-                    "minlv": 48,
+                    "minlv": 49,
                     "monsNo": 362
                 }
             ],
@@ -46359,19 +46389,19 @@
                 },
                 {
                     "maxlv": 49,
-                    "minlv": 48,
+                    "minlv": 49,
                     "monsNo": 362
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 49,
-                    "minlv": 48,
+                    "minlv": 49,
                     "monsNo": 478
                 },
                 {
                     "maxlv": 49,
-                    "minlv": 48,
+                    "minlv": 49,
                     "monsNo": 478
                 },
                 {
@@ -46601,22 +46631,22 @@
             "ground_mons": [
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 396
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 399
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 16
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 401
                 },
                 {
@@ -46631,12 +46661,12 @@
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 32
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 29
                 },
                 {
@@ -46663,58 +46693,58 @@
             "tairyo": [
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 16
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 401
                 }
             ],
             "day": [
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 16
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 16
                 }
             ],
             "night": [
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 163
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 401
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 5,
-                    "minlv": 3,
+                    "minlv": 5,
                     "monsNo": 84
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 3,
+                    "minlv": 5,
                     "monsNo": 84
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 84
                 },
                 {
                     "maxlv": 5,
-                    "minlv": 4,
+                    "minlv": 5,
                     "monsNo": 84
                 }
             ],
@@ -46934,42 +46964,42 @@
             "ground_mons": [
                 {
                     "maxlv": 6,
-                    "minlv": 5,
+                    "minlv": 6,
                     "monsNo": 403
                 },
                 {
                     "maxlv": 6,
-                    "minlv": 5,
+                    "minlv": 6,
                     "monsNo": 263
                 },
                 {
                     "maxlv": 6,
-                    "minlv": 5,
-                    "monsNo": 163
+                    "minlv": 6,
+                    "monsNo": 161
                 },
                 {
                     "maxlv": 6,
-                    "minlv": 5,
-                    "monsNo": 163
+                    "minlv": 6,
+                    "monsNo": 161
                 },
                 {
                     "maxlv": 6,
-                    "minlv": 5,
+                    "minlv": 6,
                     "monsNo": 19
                 },
                 {
                     "maxlv": 6,
-                    "minlv": 5,
+                    "minlv": 6,
                     "monsNo": 412
                 },
                 {
                     "maxlv": 6,
-                    "minlv": 5,
+                    "minlv": 6,
                     "monsNo": 58
                 },
                 {
                     "maxlv": 6,
-                    "minlv": 5,
+                    "minlv": 6,
                     "monsNo": 261
                 },
                 {
@@ -46996,48 +47026,48 @@
             "tairyo": [
                 {
                     "maxlv": 6,
-                    "minlv": 5,
+                    "minlv": 6,
                     "monsNo": 161
                 },
                 {
                     "maxlv": 6,
-                    "minlv": 5,
+                    "minlv": 6,
                     "monsNo": 161
                 }
             ],
             "day": [
                 {
                     "maxlv": 6,
-                    "minlv": 5,
+                    "minlv": 6,
                     "monsNo": 161
                 },
                 {
                     "maxlv": 6,
-                    "minlv": 5,
+                    "minlv": 6,
                     "monsNo": 161
                 }
             ],
             "night": [
                 {
                     "maxlv": 6,
-                    "minlv": 5,
+                    "minlv": 6,
                     "monsNo": 163
                 },
                 {
                     "maxlv": 6,
-                    "minlv": 5,
+                    "minlv": 6,
                     "monsNo": 163
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 6,
-                    "minlv": 5,
+                    "minlv": 6,
                     "monsNo": 228
                 },
                 {
                     "maxlv": 6,
-                    "minlv": 5,
+                    "minlv": 6,
                     "monsNo": 228
                 },
                 {
@@ -47267,32 +47297,32 @@
             "ground_mons": [
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 396
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 399
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 21
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 104
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 270
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 273
                 },
                 {
@@ -47302,7 +47332,7 @@
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 63
                 },
                 {
@@ -47329,48 +47359,48 @@
             "tairyo": [
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 21
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 104
                 }
             ],
             "day": [
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 21
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 104
                 }
             ],
             "night": [
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 21
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 104
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 204
                 },
                 {
                     "maxlv": 8,
-                    "minlv": 7,
+                    "minlv": 8,
                     "monsNo": 204
                 },
                 {
@@ -47408,7 +47438,7 @@
                     "monsNo": 65799
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -47425,7 +47455,7 @@
                     "monsNo": 65799
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -47442,7 +47472,7 @@
                     "monsNo": 65799
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -47459,7 +47489,7 @@
                     "monsNo": 65799
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -47476,7 +47506,7 @@
                     "monsNo": 65799
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -47484,28 +47514,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 54
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 54
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 54
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 55
                 }
             ],
@@ -47600,42 +47630,42 @@
             "ground_mons": [
                 {
                     "maxlv": 7,
-                    "minlv": 6,
+                    "minlv": 7,
                     "monsNo": 396
                 },
                 {
                     "maxlv": 7,
-                    "minlv": 6,
+                    "minlv": 7,
                     "monsNo": 406
                 },
                 {
                     "maxlv": 7,
-                    "minlv": 6,
+                    "minlv": 7,
                     "monsNo": 265
                 },
                 {
                     "maxlv": 7,
-                    "minlv": 6,
+                    "minlv": 7,
                     "monsNo": 165
                 },
                 {
                     "maxlv": 7,
-                    "minlv": 6,
+                    "minlv": 7,
                     "monsNo": 10
                 },
                 {
                     "maxlv": 7,
-                    "minlv": 6,
+                    "minlv": 7,
                     "monsNo": 13
                 },
                 {
                     "maxlv": 7,
-                    "minlv": 6,
+                    "minlv": 7,
                     "monsNo": 69
                 },
                 {
                     "maxlv": 7,
-                    "minlv": 6,
+                    "minlv": 7,
                     "monsNo": 280
                 },
                 {
@@ -47662,48 +47692,48 @@
             "tairyo": [
                 {
                     "maxlv": 7,
-                    "minlv": 6,
+                    "minlv": 7,
                     "monsNo": 265
                 },
                 {
                     "maxlv": 7,
-                    "minlv": 6,
+                    "minlv": 7,
                     "monsNo": 165
                 }
             ],
             "day": [
                 {
                     "maxlv": 7,
-                    "minlv": 6,
+                    "minlv": 7,
                     "monsNo": 265
                 },
                 {
                     "maxlv": 7,
-                    "minlv": 6,
+                    "minlv": 7,
                     "monsNo": 191
                 }
             ],
             "night": [
                 {
                     "maxlv": 7,
-                    "minlv": 6,
+                    "minlv": 7,
                     "monsNo": 43
                 },
                 {
                     "maxlv": 7,
-                    "minlv": 6,
+                    "minlv": 7,
                     "monsNo": 167
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 7,
-                    "minlv": 6,
+                    "minlv": 7,
                     "monsNo": 315
                 },
                 {
                     "maxlv": 7,
-                    "minlv": 6,
+                    "minlv": 7,
                     "monsNo": 315
                 },
                 {
@@ -47741,7 +47771,7 @@
                     "monsNo": 25
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -47758,7 +47788,7 @@
                     "monsNo": 25
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -47775,7 +47805,7 @@
                     "monsNo": 25
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -47792,7 +47822,7 @@
                     "monsNo": 25
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -47809,7 +47839,7 @@
                     "monsNo": 25
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -47817,28 +47847,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 183
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 183
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 183
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 184
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 184
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 184
                 }
             ],
@@ -47933,42 +47963,42 @@
             "ground_mons": [
                 {
                     "maxlv": 12,
-                    "minlv": 11,
+                    "minlv": 12,
                     "monsNo": 396
                 },
                 {
                     "maxlv": 12,
-                    "minlv": 11,
+                    "minlv": 12,
                     "monsNo": 406
                 },
                 {
                     "maxlv": 12,
-                    "minlv": 11,
+                    "minlv": 12,
                     "monsNo": 265
                 },
                 {
                     "maxlv": 12,
-                    "minlv": 11,
+                    "minlv": 12,
                     "monsNo": 165
                 },
                 {
                     "maxlv": 12,
-                    "minlv": 11,
+                    "minlv": 12,
                     "monsNo": 10
                 },
                 {
                     "maxlv": 12,
-                    "minlv": 11,
+                    "minlv": 12,
                     "monsNo": 13
                 },
                 {
                     "maxlv": 12,
-                    "minlv": 11,
+                    "minlv": 12,
                     "monsNo": 69
                 },
                 {
                     "maxlv": 12,
-                    "minlv": 11,
+                    "minlv": 12,
                     "monsNo": 280
                 },
                 {
@@ -47995,48 +48025,48 @@
             "tairyo": [
                 {
                     "maxlv": 12,
-                    "minlv": 11,
+                    "minlv": 12,
                     "monsNo": 265
                 },
                 {
                     "maxlv": 12,
-                    "minlv": 11,
+                    "minlv": 12,
                     "monsNo": 165
                 }
             ],
             "day": [
                 {
                     "maxlv": 12,
-                    "minlv": 11,
+                    "minlv": 12,
                     "monsNo": 265
                 },
                 {
                     "maxlv": 12,
-                    "minlv": 11,
+                    "minlv": 12,
                     "monsNo": 191
                 }
             ],
             "night": [
                 {
                     "maxlv": 12,
-                    "minlv": 11,
-                    "monsNo": 43
+                    "minlv": 12,
+                    "monsNo": 167
                 },
                 {
                     "maxlv": 12,
-                    "minlv": 11,
-                    "monsNo": 167
+                    "minlv": 12,
+                    "monsNo": 43
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 12,
-                    "minlv": 11,
+                    "minlv": 12,
                     "monsNo": 315
                 },
                 {
                     "maxlv": 12,
-                    "minlv": 11,
+                    "minlv": 12,
                     "monsNo": 315
                 },
                 {
@@ -48150,28 +48180,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 54
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 54
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 54
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 55
                 }
             ],
@@ -48266,116 +48296,116 @@
             "ground_mons": [
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 422
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 418
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 187
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 187
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 422
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 179
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 179
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 179
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 417
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 417
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 417
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 417
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 187
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 187
                 }
             ],
             "day": [
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 187
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 187
                 }
             ],
             "night": [
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 48
                 },
                 {
                     "maxlv": 13,
-                    "minlv": 11,
+                    "minlv": 13,
                     "monsNo": 48
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 13,
-                    "minlv": 12,
-                    "monsNo": 311
-                },
-                {
-                    "maxlv": 13,
-                    "minlv": 12,
+                    "minlv": 13,
                     "monsNo": 312
                 },
                 {
                     "maxlv": 13,
                     "minlv": 13,
-                    "monsNo": 311
+                    "monsNo": 312
+                },
+                {
+                    "maxlv": 13,
+                    "minlv": 13,
+                    "monsNo": 312
                 },
                 {
                     "maxlv": 13,
@@ -48407,7 +48437,7 @@
                     "monsNo": 439
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -48424,7 +48454,7 @@
                     "monsNo": 439
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -48441,7 +48471,7 @@
                     "monsNo": 439
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -48458,7 +48488,7 @@
                     "monsNo": 439
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -48475,7 +48505,7 @@
                     "monsNo": 439
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -48483,28 +48513,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 422
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 72
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 423
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 73
                 }
             ],
@@ -48599,52 +48629,52 @@
             "ground_mons": [
                 {
                     "maxlv": 17,
-                    "minlv": 15,
+                    "minlv": 17,
                     "monsNo": 399
                 },
                 {
                     "maxlv": 17,
-                    "minlv": 16,
+                    "minlv": 17,
                     "monsNo": 79
                 },
                 {
                     "maxlv": 17,
-                    "minlv": 15,
+                    "minlv": 17,
                     "monsNo": 183
                 },
                 {
                     "maxlv": 17,
-                    "minlv": 16,
+                    "minlv": 17,
                     "monsNo": 453
                 },
                 {
                     "maxlv": 17,
-                    "minlv": 16,
+                    "minlv": 17,
                     "monsNo": 102
                 },
                 {
                     "maxlv": 17,
-                    "minlv": 16,
+                    "minlv": 17,
                     "monsNo": 183
                 },
                 {
                     "maxlv": 17,
-                    "minlv": 15,
+                    "minlv": 17,
                     "monsNo": 313
                 },
                 {
                     "maxlv": 17,
-                    "minlv": 15,
+                    "minlv": 17,
                     "monsNo": 314
                 },
                 {
                     "maxlv": 17,
-                    "minlv": 16,
+                    "minlv": 17,
                     "monsNo": 313
                 },
                 {
                     "maxlv": 17,
-                    "minlv": 16,
+                    "minlv": 17,
                     "monsNo": 314
                 },
                 {
@@ -48661,48 +48691,48 @@
             "tairyo": [
                 {
                     "maxlv": 17,
-                    "minlv": 15,
+                    "minlv": 17,
                     "monsNo": 183
                 },
                 {
                     "maxlv": 17,
-                    "minlv": 16,
+                    "minlv": 17,
                     "monsNo": 453
                 }
             ],
             "day": [
                 {
                     "maxlv": 17,
-                    "minlv": 15,
+                    "minlv": 17,
                     "monsNo": 183
                 },
                 {
                     "maxlv": 17,
-                    "minlv": 16,
+                    "minlv": 17,
                     "monsNo": 453
                 }
             ],
             "night": [
                 {
                     "maxlv": 17,
-                    "minlv": 15,
+                    "minlv": 17,
                     "monsNo": 183
                 },
                 {
                     "maxlv": 17,
-                    "minlv": 16,
+                    "minlv": 17,
                     "monsNo": 453
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 17,
-                    "minlv": 16,
+                    "minlv": 17,
                     "monsNo": 193
                 },
                 {
                     "maxlv": 17,
-                    "minlv": 16,
+                    "minlv": 17,
                     "monsNo": 193
                 },
                 {
@@ -48740,7 +48770,7 @@
                     "monsNo": 65594
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -48757,7 +48787,7 @@
                     "monsNo": 65594
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -48774,7 +48804,7 @@
                     "monsNo": 65594
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -48791,7 +48821,7 @@
                     "monsNo": 65594
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -48808,7 +48838,7 @@
                     "monsNo": 65594
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -48816,28 +48846,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 183
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 183
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 183
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 184
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 184
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 184
                 }
             ],
@@ -48932,47 +48962,37 @@
             "ground_mons": [
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 434
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 218
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 20,
+                    "minlv": 22,
                     "monsNo": 56
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 56
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 20,
+                    "minlv": 22,
                     "monsNo": 240
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 325
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 20,
-                    "monsNo": 322
-                },
-                {
-                    "maxlv": 22,
-                    "minlv": 21,
-                    "monsNo": 207
-                },
-                {
-                    "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 322
                 },
                 {
@@ -48982,7 +49002,17 @@
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
+                    "monsNo": 322
+                },
+                {
+                    "maxlv": 22,
+                    "minlv": 22,
+                    "monsNo": 207
+                },
+                {
+                    "maxlv": 22,
+                    "minlv": 22,
                     "monsNo": 322
                 },
                 {
@@ -48994,48 +49024,48 @@
             "tairyo": [
                 {
                     "maxlv": 22,
-                    "minlv": 20,
+                    "minlv": 22,
                     "monsNo": 56
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 56
                 }
             ],
             "day": [
                 {
                     "maxlv": 22,
-                    "minlv": 20,
+                    "minlv": 22,
                     "monsNo": 56
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 56
                 }
             ],
             "night": [
                 {
                     "maxlv": 22,
-                    "minlv": 20,
+                    "minlv": 22,
                     "monsNo": 56
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 56
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 324
                 },
                 {
                     "maxlv": 22,
-                    "minlv": 21,
+                    "minlv": 22,
                     "monsNo": 324
                 },
                 {
@@ -49265,12 +49295,12 @@
             "ground_mons": [
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 66
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 231
                 },
                 {
@@ -49280,12 +49310,12 @@
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 111
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 77
                 },
                 {
@@ -49295,17 +49325,17 @@
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 246
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 246
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 77
                 },
                 {
@@ -49332,7 +49362,7 @@
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 111
                 }
             ],
@@ -49344,7 +49374,7 @@
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 111
                 }
             ],
@@ -49356,29 +49386,29 @@
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 9,
+                    "minlv": 10,
                     "monsNo": 111
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 10,
-                    "minlv": 6,
+                    "minlv": 10,
                     "monsNo": 234
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 6,
+                    "minlv": 10,
                     "monsNo": 234
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 7,
+                    "minlv": 10,
                     "monsNo": 234
                 },
                 {
                     "maxlv": 10,
-                    "minlv": 7,
+                    "minlv": 10,
                     "monsNo": 234
                 }
             ],
@@ -49603,37 +49633,37 @@
                 },
                 {
                     "maxlv": 24,
-                    "minlv": 23,
+                    "minlv": 24,
                     "monsNo": 315
                 },
                 {
                     "maxlv": 24,
-                    "minlv": 23,
+                    "minlv": 24,
                     "monsNo": 300
                 },
                 {
                     "maxlv": 24,
-                    "minlv": 23,
+                    "minlv": 24,
                     "monsNo": 39
                 },
                 {
                     "maxlv": 24,
-                    "minlv": 23,
+                    "minlv": 24,
                     "monsNo": 281
                 },
                 {
                     "maxlv": 24,
-                    "minlv": 23,
+                    "minlv": 24,
                     "monsNo": 235
                 },
                 {
                     "maxlv": 24,
-                    "minlv": 23,
+                    "minlv": 24,
                     "monsNo": 335
                 },
                 {
                     "maxlv": 24,
-                    "minlv": 23,
+                    "minlv": 24,
                     "monsNo": 336
                 },
                 {
@@ -49660,48 +49690,48 @@
             "tairyo": [
                 {
                     "maxlv": 24,
-                    "minlv": 23,
+                    "minlv": 24,
                     "monsNo": 300
                 },
                 {
                     "maxlv": 24,
-                    "minlv": 23,
+                    "minlv": 24,
                     "monsNo": 39
                 }
             ],
             "day": [
                 {
                     "maxlv": 24,
-                    "minlv": 23,
+                    "minlv": 24,
                     "monsNo": 300
                 },
                 {
                     "maxlv": 24,
-                    "minlv": 23,
+                    "minlv": 24,
                     "monsNo": 39
                 }
             ],
             "night": [
                 {
                     "maxlv": 24,
-                    "minlv": 23,
+                    "minlv": 24,
                     "monsNo": 300
                 },
                 {
                     "maxlv": 24,
-                    "minlv": 23,
+                    "minlv": 24,
                     "monsNo": 39
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 24,
-                    "minlv": 23,
+                    "minlv": 24,
                     "monsNo": 206
                 },
                 {
                     "maxlv": 24,
-                    "minlv": 23,
+                    "minlv": 24,
                     "monsNo": 206
                 },
                 {
@@ -49739,7 +49769,7 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -49756,7 +49786,7 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -49773,7 +49803,7 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -49790,7 +49820,7 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -49807,7 +49837,7 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -49815,28 +49845,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 54
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 54
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 54
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 55
                 }
             ],
@@ -49936,22 +49966,22 @@
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 431
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 26,
+                    "minlv": 26,
                     "monsNo": 37
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 26,
+                    "minlv": 26,
                     "monsNo": 209
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 52
                 },
                 {
@@ -49961,90 +49991,90 @@
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 24,
+                    "minlv": 26,
                     "monsNo": 439
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 24,
+                    "minlv": 26,
                     "monsNo": 438
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 24,
+                    "minlv": 26,
                     "monsNo": 439
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 24,
+                    "minlv": 26,
                     "monsNo": 438
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 24,
+                    "minlv": 26,
                     "monsNo": 439
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 24,
+                    "minlv": 26,
                     "monsNo": 438
                 }
             ],
             "tairyo": [
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 26,
+                    "minlv": 26,
                     "monsNo": 37
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 26,
+                    "minlv": 26,
                     "monsNo": 209
                 }
             ],
             "day": [
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 26,
+                    "minlv": 26,
                     "monsNo": 37
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 26,
+                    "minlv": 26,
                     "monsNo": 209
                 }
             ],
             "night": [
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 26,
+                    "minlv": 26,
                     "monsNo": 37
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 26,
+                    "minlv": 26,
                     "monsNo": 209
                 }
             ],
             "swayGrass": [
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 26,
+                    "minlv": 26,
                     "monsNo": 432
                 },
                 {
-                    "maxlv": 24,
-                    "minlv": 24,
+                    "maxlv": 26,
+                    "minlv": 26,
                     "monsNo": 432
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 26,
+                    "minlv": 26,
                     "monsNo": 432
                 },
                 {
-                    "maxlv": 25,
-                    "minlv": 25,
+                    "maxlv": 26,
+                    "minlv": 26,
                     "monsNo": 432
                 }
             ],
@@ -50072,7 +50102,7 @@
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -50089,7 +50119,7 @@
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -50106,7 +50136,7 @@
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -50123,7 +50153,7 @@
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -50140,7 +50170,7 @@
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -50148,28 +50178,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 54
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 54
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 54
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 55
                 }
             ],
@@ -50264,120 +50294,120 @@
             "ground_mons": [
                 {
                     "maxlv": 30,
-                    "minlv": 26,
+                    "minlv": 30,
                     "monsNo": 353
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 26,
+                    "minlv": 30,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 198
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 200
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 354
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 354
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 30,
-                    "minlv": 27,
-                    "monsNo": 42
+                    "minlv": 30,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
-                    "monsNo": 93
+                    "minlv": 30,
+                    "monsNo": 42
                 }
             ],
             "day": [
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 42
                 }
             ],
             "night": [
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 42
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 30,
-                    "minlv": 26,
-                    "monsNo": 198
+                    "minlv": 30,
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 26,
-                    "monsNo": 200
+                    "minlv": 30,
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
-                    "monsNo": 356
+                    "minlv": 30,
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 354
                 }
             ],
@@ -50396,12 +50426,12 @@
             "gbaRuby": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -50413,12 +50443,12 @@
             "gbaSapp": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -50430,12 +50460,12 @@
             "gbaEme": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -50447,12 +50477,12 @@
             "gbaFire": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -50464,12 +50494,12 @@
             "gbaLeaf": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -50597,120 +50627,120 @@
             "ground_mons": [
                 {
                     "maxlv": 30,
-                    "minlv": 26,
+                    "minlv": 30,
                     "monsNo": 353
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 26,
+                    "minlv": 30,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
-                    "monsNo": 42
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
+                    "monsNo": 42
+                },
+                {
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 198
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 200
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 354
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 354
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 30,
-                    "minlv": 27,
-                    "monsNo": 42
+                    "minlv": 30,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
-                    "monsNo": 93
+                    "minlv": 30,
+                    "monsNo": 42
                 }
             ],
             "day": [
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 42
                 }
             ],
             "night": [
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 42
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 30,
-                    "minlv": 26,
-                    "monsNo": 198
+                    "minlv": 30,
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 26,
-                    "monsNo": 200
+                    "minlv": 30,
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
-                    "monsNo": 356
+                    "minlv": 30,
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 354
                 }
             ],
@@ -50728,13 +50758,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -50745,13 +50775,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -50762,13 +50792,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -50779,13 +50809,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -50796,13 +50826,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -50930,120 +50960,120 @@
             "ground_mons": [
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 353
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 198
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 200
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 354
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 354
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 30,
-                    "minlv": 28,
-                    "monsNo": 42
+                    "minlv": 30,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
-                    "monsNo": 93
+                    "minlv": 30,
+                    "monsNo": 42
                 }
             ],
             "day": [
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 42
                 }
             ],
             "night": [
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 42
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 30,
-                    "minlv": 27,
-                    "monsNo": 198
+                    "minlv": 30,
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
-                    "monsNo": 200
+                    "minlv": 30,
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
-                    "monsNo": 356
+                    "minlv": 30,
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 354
                 }
             ],
@@ -51062,12 +51092,12 @@
             "gbaRuby": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -51079,12 +51109,12 @@
             "gbaSapp": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -51096,12 +51126,12 @@
             "gbaEme": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -51113,12 +51143,12 @@
             "gbaFire": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -51130,12 +51160,12 @@
             "gbaLeaf": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -51263,120 +51293,120 @@
             "ground_mons": [
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 353
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 198
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 200
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 42
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 354
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 356
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 354
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 30,
-                    "minlv": 28,
-                    "monsNo": 42
+                    "minlv": 30,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
-                    "monsNo": 93
+                    "minlv": 30,
+                    "monsNo": 42
                 }
             ],
             "day": [
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 42
                 }
             ],
             "night": [
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 42
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 30,
-                    "minlv": 27,
-                    "monsNo": 198
+                    "minlv": 30,
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
-                    "monsNo": 200
+                    "minlv": 30,
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
-                    "monsNo": 356
+                    "minlv": 30,
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 354
                 }
             ],
@@ -51394,13 +51424,13 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -51411,13 +51441,13 @@
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -51428,13 +51458,13 @@
             ],
             "gbaEme": [
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -51445,13 +51475,13 @@
             ],
             "gbaFire": [
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -51462,13 +51492,13 @@
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
-                    "maxlv": 29,
-                    "minlv": 29,
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 109
                 },
                 {
@@ -51596,32 +51626,32 @@
             "ground_mons": [
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 353
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 355
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
-                    "monsNo": 42
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
+                    "monsNo": 42
+                },
+                {
+                    "maxlv": 30,
+                    "minlv": 30,
                     "monsNo": 198
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 200
                 },
                 {
@@ -51658,54 +51688,54 @@
             "tairyo": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
-                    "monsNo": 42
+                    "minlv": 30,
+                    "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
-                    "monsNo": 93
+                    "minlv": 30,
+                    "monsNo": 42
                 }
             ],
             "day": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 42
                 }
             ],
             "night": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 93
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 42
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
-                    "monsNo": 198
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 29,
-                    "monsNo": 200
+                    "minlv": 30,
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
                     "minlv": 30,
-                    "monsNo": 356
+                    "monsNo": 354
+                },
+                {
+                    "maxlv": 30,
+                    "minlv": 30,
+                    "monsNo": 354
                 },
                 {
                     "maxlv": 30,
@@ -51929,32 +51959,32 @@
             "ground_mons": [
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 402
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 274
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 127
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
-                    "monsNo": 164
+                    "minlv": 30,
+                    "monsNo": 17
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 241
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 128
                 },
                 {
@@ -51964,17 +51994,17 @@
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 123
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 123
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 123
                 },
                 {
@@ -51991,48 +52021,48 @@
             "tairyo": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 127
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 17
                 }
             ],
             "day": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 127
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 17
                 }
             ],
             "night": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 127
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 164
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 352
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 352
                 },
                 {
@@ -52262,17 +52292,17 @@
             "ground_mons": [
                 {
                     "maxlv": 38,
-                    "minlv": 34,
+                    "minlv": 38,
                     "monsNo": 333
                 },
                 {
                     "maxlv": 38,
-                    "minlv": 37,
+                    "minlv": 38,
                     "monsNo": 22
                 },
                 {
                     "maxlv": 38,
-                    "minlv": 36,
+                    "minlv": 38,
                     "monsNo": 67
                 },
                 {
@@ -52292,22 +52322,22 @@
                 },
                 {
                     "maxlv": 38,
-                    "minlv": 37,
+                    "minlv": 38,
                     "monsNo": 227
                 },
                 {
                     "maxlv": 38,
-                    "minlv": 37,
+                    "minlv": 38,
                     "monsNo": 372
                 },
                 {
                     "maxlv": 38,
-                    "minlv": 37,
+                    "minlv": 38,
                     "monsNo": 227
                 },
                 {
                     "maxlv": 38,
-                    "minlv": 37,
+                    "minlv": 38,
                     "monsNo": 372
                 },
                 {
@@ -52324,7 +52354,7 @@
             "tairyo": [
                 {
                     "maxlv": 38,
-                    "minlv": 36,
+                    "minlv": 38,
                     "monsNo": 67
                 },
                 {
@@ -52336,7 +52366,7 @@
             "day": [
                 {
                     "maxlv": 38,
-                    "minlv": 36,
+                    "minlv": 38,
                     "monsNo": 67
                 },
                 {
@@ -52348,7 +52378,7 @@
             "night": [
                 {
                     "maxlv": 38,
-                    "minlv": 36,
+                    "minlv": 38,
                     "monsNo": 67
                 },
                 {
@@ -52360,12 +52390,12 @@
             "swayGrass": [
                 {
                     "maxlv": 38,
-                    "minlv": 37,
+                    "minlv": 38,
                     "monsNo": 352
                 },
                 {
                     "maxlv": 38,
-                    "minlv": 37,
+                    "minlv": 38,
                     "monsNo": 352
                 },
                 {
@@ -52403,7 +52433,7 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -52420,7 +52450,7 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -52437,7 +52467,7 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -52454,7 +52484,7 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -52471,7 +52501,7 @@
                     "monsNo": 65646
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -52479,28 +52509,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 54
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 54
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 54
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 55
                 }
             ],
@@ -52595,42 +52625,42 @@
             "ground_mons": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 307
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 66
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 333
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 216
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 177
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 433
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 333
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 307
                 },
                 {
@@ -52657,48 +52687,48 @@
             "tairyo": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 333
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 216
                 }
             ],
             "day": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 333
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 216
                 }
             ],
             "night": [
                 {
                     "maxlv": 18,
-                    "minlv": 16,
+                    "minlv": 18,
                     "monsNo": 333
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 216
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 236
                 },
                 {
                     "maxlv": 18,
-                    "minlv": 17,
+                    "minlv": 18,
                     "monsNo": 236
                 },
                 {
@@ -52928,17 +52958,17 @@
             "ground_mons": [
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 307
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 333
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 307
                 },
                 {
@@ -52953,56 +52983,56 @@
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 371
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 216
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 177
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 216
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 177
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 216
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 177
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 19,
-                    "minlv": 18,
-                    "monsNo": 66
+                    "minlv": 19,
+                    "monsNo": 307
                 },
                 {
                     "maxlv": 19,
                     "minlv": 19,
-                    "monsNo": 307
+                    "monsNo": 66
                 }
             ],
             "day": [
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 307
                 },
                 {
@@ -53014,7 +53044,7 @@
             "night": [
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 307
                 },
                 {
@@ -53026,12 +53056,12 @@
             "swayGrass": [
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 236
                 },
                 {
                     "maxlv": 19,
-                    "minlv": 18,
+                    "minlv": 19,
                     "monsNo": 236
                 },
                 {
@@ -53261,17 +53291,17 @@
             "ground_mons": [
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 397
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 24,
+                    "minlv": 26,
                     "monsNo": 183
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 315
                 },
                 {
@@ -53281,27 +53311,27 @@
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 44
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 281
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 24,
+                    "minlv": 26,
                     "monsNo": 235
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 235
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 397
                 },
                 {
@@ -53311,7 +53341,7 @@
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 397
                 },
                 {
@@ -53323,7 +53353,7 @@
             "tairyo": [
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 315
                 },
                 {
@@ -53335,7 +53365,7 @@
             "day": [
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 315
                 },
                 {
@@ -53347,7 +53377,7 @@
             "night": [
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 315
                 },
                 {
@@ -53359,12 +53389,12 @@
             "swayGrass": [
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 83
                 },
                 {
                     "maxlv": 26,
-                    "minlv": 25,
+                    "minlv": 26,
                     "monsNo": 83
                 },
                 {
@@ -53402,7 +53432,7 @@
                     "monsNo": 216
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -53419,7 +53449,7 @@
                     "monsNo": 216
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -53436,7 +53466,7 @@
                     "monsNo": 216
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -53453,7 +53483,7 @@
                     "monsNo": 216
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -53470,7 +53500,7 @@
                     "monsNo": 216
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -53478,28 +53508,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 183
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 183
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 30,
+                    "minlv": 40,
+                    "monsNo": 183
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 184
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 30,
+                    "minlv": 40,
                     "monsNo": 184
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 30,
+                    "minlv": 40,
                     "monsNo": 184
                 }
             ],
@@ -53594,22 +53624,22 @@
             "ground_mons": [
                 {
                     "maxlv": 36,
-                    "minlv": 33,
+                    "minlv": 36,
                     "monsNo": 453
                 },
                 {
                     "maxlv": 36,
-                    "minlv": 33,
+                    "minlv": 36,
                     "monsNo": 88
                 },
                 {
                     "maxlv": 36,
-                    "minlv": 33,
+                    "minlv": 36,
                     "monsNo": 109
                 },
                 {
                     "maxlv": 36,
-                    "minlv": 33,
+                    "minlv": 36,
                     "monsNo": 23
                 },
                 {
@@ -53624,86 +53654,86 @@
                 },
                 {
                     "maxlv": 36,
-                    "minlv": 34,
+                    "minlv": 36,
+                    "monsNo": 24
+                },
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 454
+                },
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
                     "monsNo": 109
                 },
                 {
                     "maxlv": 36,
-                    "minlv": 34,
+                    "minlv": 36,
                     "monsNo": 23
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 24
+                    "monsNo": 109
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 454
-                },
-                {
-                    "maxlv": 36,
-                    "minlv": 36,
-                    "monsNo": 24
-                },
-                {
-                    "maxlv": 36,
-                    "minlv": 36,
-                    "monsNo": 454
+                    "monsNo": 23
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 36,
-                    "minlv": 33,
+                    "minlv": 36,
                     "monsNo": 109
                 },
                 {
                     "maxlv": 36,
-                    "minlv": 33,
+                    "minlv": 36,
                     "monsNo": 23
                 }
             ],
             "day": [
                 {
                     "maxlv": 36,
-                    "minlv": 33,
+                    "minlv": 36,
                     "monsNo": 109
                 },
                 {
                     "maxlv": 36,
-                    "minlv": 33,
+                    "minlv": 36,
                     "monsNo": 23
                 }
             ],
             "night": [
                 {
                     "maxlv": 36,
-                    "minlv": 33,
+                    "minlv": 36,
                     "monsNo": 109
                 },
                 {
                     "maxlv": 36,
-                    "minlv": 33,
+                    "minlv": 36,
                     "monsNo": 23
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 36,
-                    "minlv": 35,
-                    "monsNo": 110
-                },
-                {
-                    "maxlv": 36,
-                    "minlv": 35,
+                    "minlv": 36,
                     "monsNo": 89
                 },
                 {
                     "maxlv": 36,
                     "minlv": 36,
-                    "monsNo": 110
+                    "monsNo": 89
+                },
+                {
+                    "maxlv": 36,
+                    "minlv": 36,
+                    "monsNo": 89
                 },
                 {
                     "maxlv": 36,
@@ -53735,7 +53765,7 @@
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -53752,7 +53782,7 @@
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -53769,7 +53799,7 @@
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -53786,7 +53816,7 @@
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -53803,7 +53833,7 @@
                     "monsNo": 123
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -53811,28 +53841,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 65958
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 194
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 423
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 195
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 195
                 }
             ],
@@ -53927,37 +53957,37 @@
             "ground_mons": [
                 {
                     "maxlv": 34,
-                    "minlv": 33,
+                    "minlv": 34,
                     "monsNo": 279
                 },
                 {
                     "maxlv": 34,
-                    "minlv": 33,
+                    "minlv": 34,
                     "monsNo": 419
                 },
                 {
                     "maxlv": 34,
-                    "minlv": 32,
+                    "minlv": 34,
                     "monsNo": 65959
                 },
                 {
                     "maxlv": 34,
-                    "minlv": 32,
+                    "minlv": 34,
+                    "monsNo": 441
+                },
+                {
+                    "maxlv": 34,
+                    "minlv": 34,
                     "monsNo": 65959
                 },
                 {
                     "maxlv": 34,
-                    "minlv": 33,
-                    "monsNo": 65959
-                },
-                {
-                    "maxlv": 34,
-                    "minlv": 32,
+                    "minlv": 34,
                     "monsNo": 213
                 },
                 {
                     "maxlv": 34,
-                    "minlv": 32,
+                    "minlv": 34,
                     "monsNo": 65959
                 },
                 {
@@ -53967,12 +53997,12 @@
                 },
                 {
                     "maxlv": 34,
-                    "minlv": 33,
+                    "minlv": 34,
                     "monsNo": 277
                 },
                 {
                     "maxlv": 34,
-                    "minlv": 33,
+                    "minlv": 34,
                     "monsNo": 277
                 },
                 {
@@ -53989,48 +54019,48 @@
             "tairyo": [
                 {
                     "maxlv": 34,
-                    "minlv": 32,
+                    "minlv": 34,
                     "monsNo": 65959
                 },
                 {
                     "maxlv": 34,
-                    "minlv": 32,
+                    "minlv": 34,
                     "monsNo": 441
                 }
             ],
             "day": [
                 {
                     "maxlv": 34,
-                    "minlv": 32,
+                    "minlv": 34,
                     "monsNo": 65959
                 },
                 {
                     "maxlv": 34,
-                    "minlv": 32,
+                    "minlv": 34,
                     "monsNo": 441
                 }
             ],
             "night": [
                 {
                     "maxlv": 34,
-                    "minlv": 32,
+                    "minlv": 34,
                     "monsNo": 65959
                 },
                 {
                     "maxlv": 34,
-                    "minlv": 32,
+                    "minlv": 34,
                     "monsNo": 65959
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 34,
-                    "minlv": 33,
+                    "minlv": 34,
                     "monsNo": 359
                 },
                 {
                     "maxlv": 34,
-                    "minlv": 33,
+                    "minlv": 34,
                     "monsNo": 359
                 },
                 {
@@ -54068,7 +54098,7 @@
                     "monsNo": 65800
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -54085,7 +54115,7 @@
                     "monsNo": 65800
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -54102,7 +54132,7 @@
                     "monsNo": 65800
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -54119,7 +54149,7 @@
                     "monsNo": 65800
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -54136,7 +54166,7 @@
                     "monsNo": 65800
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -54144,28 +54174,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 72
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 278
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 279
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 279
                 }
             ],
@@ -54260,52 +54290,52 @@
             "ground_mons": [
                 {
                     "maxlv": 32,
-                    "minlv": 30,
+                    "minlv": 32,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 228
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 111
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 322
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 325
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 331
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 30,
+                    "minlv": 32,
                     "monsNo": 111
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 322
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 31,
+                    "minlv": 32,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 31,
+                    "minlv": 32,
                     "monsNo": 75
                 },
                 {
@@ -54322,48 +54352,48 @@
             "tairyo": [
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 111
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 322
                 }
             ],
             "day": [
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 111
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 322
                 }
             ],
             "night": [
                 {
                     "maxlv": 32,
-                    "minlv": 29,
+                    "minlv": 32,
                     "monsNo": 111
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 28,
+                    "minlv": 32,
                     "monsNo": 322
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 32,
-                    "minlv": 31,
+                    "minlv": 32,
                     "monsNo": 327
                 },
                 {
                     "maxlv": 32,
-                    "minlv": 31,
+                    "minlv": 32,
                     "monsNo": 327
                 },
                 {
@@ -54401,7 +54431,7 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -54418,7 +54448,7 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -54435,7 +54465,7 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -54452,7 +54482,7 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -54469,7 +54499,7 @@
                     "monsNo": 65619
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65615
                 }
@@ -54477,28 +54507,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 54
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 54
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 54
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 55
                 }
             ],
@@ -54593,37 +54623,37 @@
             "ground_mons": [
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 183
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 27,
+                    "minlv": 30,
                     "monsNo": 96
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 108
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 64
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 262
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 264
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 183
                 },
                 {
@@ -54633,12 +54663,12 @@
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 108
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 64
                 },
                 {
@@ -54655,48 +54685,48 @@
             "tairyo": [
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 108
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 64
                 }
             ],
             "day": [
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 108
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 64
                 }
             ],
             "night": [
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 108
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 28,
+                    "minlv": 30,
                     "monsNo": 64
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 359
                 },
                 {
                     "maxlv": 30,
-                    "minlv": 29,
+                    "minlv": 30,
                     "monsNo": 359
                 },
                 {
@@ -54926,52 +54956,52 @@
             "ground_mons": [
                 {
                     "maxlv": 20,
-                    "minlv": 18,
+                    "minlv": 20,
                     "monsNo": 459
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 18,
+                    "minlv": 20,
                     "monsNo": 220
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 18,
+                    "minlv": 20,
                     "monsNo": 238
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 18,
+                    "minlv": 20,
                     "monsNo": 361
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 459
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 238
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 220
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 361
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 18,
+                    "minlv": 20,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 215
                 },
                 {
@@ -54988,48 +55018,48 @@
             "tairyo": [
                 {
                     "maxlv": 20,
-                    "minlv": 18,
+                    "minlv": 20,
                     "monsNo": 238
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 18,
+                    "minlv": 20,
                     "monsNo": 361
                 }
             ],
             "day": [
                 {
                     "maxlv": 20,
-                    "minlv": 18,
+                    "minlv": 20,
                     "monsNo": 238
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 18,
+                    "minlv": 20,
                     "monsNo": 361
                 }
             ],
             "night": [
                 {
                     "maxlv": 20,
-                    "minlv": 18,
+                    "minlv": 20,
                     "monsNo": 238
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 18,
+                    "minlv": 20,
                     "monsNo": 361
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 225
                 },
                 {
                     "maxlv": 20,
-                    "minlv": 19,
+                    "minlv": 20,
                     "monsNo": 225
                 },
                 {
@@ -55259,12 +55289,12 @@
             "ground_mons": [
                 {
                     "maxlv": 48,
-                    "minlv": 46,
+                    "minlv": 48,
                     "monsNo": 221
                 },
                 {
                     "maxlv": 48,
-                    "minlv": 44,
+                    "minlv": 48,
                     "monsNo": 361
                 },
                 {
@@ -55274,32 +55304,32 @@
                 },
                 {
                     "maxlv": 48,
-                    "minlv": 47,
+                    "minlv": 48,
                     "monsNo": 362
                 },
                 {
                     "maxlv": 48,
-                    "minlv": 47,
+                    "minlv": 48,
                     "monsNo": 124
                 },
                 {
                     "maxlv": 48,
-                    "minlv": 47,
+                    "minlv": 48,
                     "monsNo": 225
                 },
                 {
                     "maxlv": 48,
-                    "minlv": 46,
+                    "minlv": 48,
                     "monsNo": 215
                 },
                 {
                     "maxlv": 48,
-                    "minlv": 47,
+                    "minlv": 48,
                     "monsNo": 221
                 },
                 {
                     "maxlv": 48,
-                    "minlv": 47,
+                    "minlv": 48,
                     "monsNo": 215
                 },
                 {
@@ -55326,7 +55356,7 @@
                 },
                 {
                     "maxlv": 48,
-                    "minlv": 47,
+                    "minlv": 48,
                     "monsNo": 362
                 }
             ],
@@ -55338,7 +55368,7 @@
                 },
                 {
                     "maxlv": 48,
-                    "minlv": 47,
+                    "minlv": 48,
                     "monsNo": 362
                 }
             ],
@@ -55350,19 +55380,19 @@
                 },
                 {
                     "maxlv": 48,
-                    "minlv": 47,
+                    "minlv": 48,
                     "monsNo": 362
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 48,
-                    "minlv": 47,
+                    "minlv": 48,
                     "monsNo": 478
                 },
                 {
                     "maxlv": 48,
-                    "minlv": 47,
+                    "minlv": 48,
                     "monsNo": 478
                 },
                 {
@@ -55607,8 +55637,8 @@
                 },
                 {
                     "maxlv": 39,
-                    "minlv": 38,
-                    "monsNo": 432
+                    "minlv": 39,
+                    "monsNo": 441
                 },
                 {
                     "maxlv": 39,
@@ -55622,7 +55652,7 @@
                 },
                 {
                     "maxlv": 39,
-                    "minlv": 38,
+                    "minlv": 39,
                     "monsNo": 132
                 },
                 {
@@ -55632,12 +55662,12 @@
                 },
                 {
                     "maxlv": 39,
-                    "minlv": 38,
+                    "minlv": 39,
                     "monsNo": 125
                 },
                 {
                     "maxlv": 39,
-                    "minlv": 38,
+                    "minlv": 39,
                     "monsNo": 125
                 },
                 {
@@ -55659,7 +55689,7 @@
                 },
                 {
                     "maxlv": 39,
-                    "minlv": 38,
+                    "minlv": 39,
                     "monsNo": 441
                 }
             ],
@@ -55671,7 +55701,7 @@
                 },
                 {
                     "maxlv": 39,
-                    "minlv": 38,
+                    "minlv": 39,
                     "monsNo": 441
                 }
             ],
@@ -55683,20 +55713,20 @@
                 },
                 {
                     "maxlv": 39,
-                    "minlv": 38,
+                    "minlv": 39,
                     "monsNo": 432
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 39,
-                    "minlv": 38,
-                    "monsNo": 122
+                    "minlv": 39,
+                    "monsNo": 125
                 },
                 {
                     "maxlv": 39,
-                    "minlv": 38,
-                    "monsNo": 101
+                    "minlv": 39,
+                    "monsNo": 125
                 },
                 {
                     "maxlv": 39,
@@ -55733,8 +55763,8 @@
                     "monsNo": 65587
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65615
                 }
             ],
@@ -55750,8 +55780,8 @@
                     "monsNo": 65587
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65615
                 }
             ],
@@ -55767,8 +55797,8 @@
                     "monsNo": 65587
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65615
                 }
             ],
@@ -55784,8 +55814,8 @@
                     "monsNo": 65587
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65615
                 }
             ],
@@ -55801,36 +55831,36 @@
                     "monsNo": 65587
                 },
                 {
-                    "maxlv": 20,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65615
                 }
             ],
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 35,
-                    "minlv": 20,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 72
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 20,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 422
                 },
                 {
-                    "maxlv": 35,
-                    "minlv": 20,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 30,
+                    "minlv": 45,
                     "monsNo": 423
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 30,
+                    "minlv": 45,
                     "monsNo": 423
                 }
             ],
@@ -56066,8 +56096,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
@@ -56083,8 +56113,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
@@ -56100,8 +56130,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
@@ -56117,8 +56147,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
@@ -56134,36 +56164,36 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
             "encRate_wat": 20,
             "water_mons": [
                 {
-                    "maxlv": 40,
-                    "minlv": 30,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 278
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 30,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 72
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 279
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 73
                 }
             ],
@@ -56258,7 +56288,7 @@
             "ground_mons": [
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 185
                 },
                 {
@@ -56268,12 +56298,12 @@
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 38,
+                    "minlv": 40,
                     "monsNo": 33
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 38,
+                    "minlv": 40,
                     "monsNo": 30
                 },
                 {
@@ -56283,12 +56313,12 @@
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 203
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 38,
+                    "minlv": 40,
                     "monsNo": 83
                 },
                 {
@@ -56298,81 +56328,81 @@
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 38,
+                    "minlv": 40,
                     "monsNo": 33
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 38,
+                    "minlv": 40,
                     "monsNo": 30
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 33
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 30
                 }
             ],
             "tairyo": [
                 {
                     "maxlv": 40,
-                    "minlv": 38,
+                    "minlv": 40,
                     "monsNo": 30
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 38,
+                    "minlv": 40,
                     "monsNo": 33
                 }
             ],
             "day": [
                 {
                     "maxlv": 40,
-                    "minlv": 38,
+                    "minlv": 40,
                     "monsNo": 33
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 38,
+                    "minlv": 40,
                     "monsNo": 30
                 }
             ],
             "night": [
                 {
                     "maxlv": 40,
-                    "minlv": 38,
+                    "minlv": 40,
                     "monsNo": 33
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 38,
+                    "minlv": 40,
                     "monsNo": 30
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 40,
-                    "minlv": 38,
-                    "monsNo": 85
-                },
-                {
-                    "maxlv": 40,
-                    "minlv": 38,
-                    "monsNo": 203
-                },
-                {
-                    "maxlv": 40,
-                    "minlv": 39,
+                    "minlv": 40,
                     "monsNo": 30
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 39,
-                    "monsNo": 33
+                    "minlv": 40,
+                    "monsNo": 30
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
+                    "monsNo": 30
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
+                    "monsNo": 30
                 }
             ],
             "FormProb": [
@@ -56389,114 +56419,114 @@
             ],
             "gbaRuby": [
                 {
-                    "maxlv": 39,
-                    "minlv": 39,
-                    "monsNo": 863
-                },
-                {
-                    "maxlv": 39,
-                    "minlv": 39,
-                    "monsNo": 863
-                },
-                {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
+                    "monsNo": 863
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
+                    "monsNo": 863
+                },
+                {
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
             "gbaSapp": [
                 {
-                    "maxlv": 39,
-                    "minlv": 39,
-                    "monsNo": 863
-                },
-                {
-                    "maxlv": 39,
-                    "minlv": 39,
-                    "monsNo": 863
-                },
-                {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
+                    "monsNo": 863
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
+                    "monsNo": 863
+                },
+                {
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
             "gbaEme": [
                 {
-                    "maxlv": 39,
-                    "minlv": 39,
-                    "monsNo": 863
-                },
-                {
-                    "maxlv": 39,
-                    "minlv": 39,
-                    "monsNo": 863
-                },
-                {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
+                    "monsNo": 863
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
+                    "monsNo": 863
+                },
+                {
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
             "gbaFire": [
                 {
-                    "maxlv": 39,
-                    "minlv": 39,
-                    "monsNo": 863
-                },
-                {
-                    "maxlv": 39,
-                    "minlv": 39,
-                    "monsNo": 863
-                },
-                {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
+                    "monsNo": 863
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
+                    "monsNo": 863
+                },
+                {
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
             "gbaLeaf": [
                 {
-                    "maxlv": 39,
-                    "minlv": 39,
-                    "monsNo": 863
-                },
-                {
-                    "maxlv": 39,
-                    "minlv": 39,
-                    "monsNo": 863
-                },
-                {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
+                    "monsNo": 863
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
+                    "monsNo": 863
+                },
+                {
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 65758
                 }
             ],
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 40,
-                    "minlv": 30,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 278
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 30,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 72
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 279
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 73
                 }
             ],
@@ -56591,7 +56621,7 @@
             "ground_mons": [
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 125
                 },
                 {
@@ -56601,13 +56631,13 @@
                 },
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 404
                 },
                 {
                     "maxlv": 54,
-                    "minlv": 53,
-                    "monsNo": 404
+                    "minlv": 54,
+                    "monsNo": 441
                 },
                 {
                     "maxlv": 54,
@@ -56616,17 +56646,17 @@
                 },
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 180
                 },
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 122
                 },
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 432
                 },
                 {
@@ -56653,48 +56683,48 @@
             "tairyo": [
                 {
                     "maxlv": 54,
-                    "minlv": 53,
-                    "monsNo": 403
+                    "minlv": 54,
+                    "monsNo": 404
                 },
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 441
                 }
             ],
             "day": [
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 404
                 },
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 441
                 }
             ],
             "night": [
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 404
                 },
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 404
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 301
                 },
                 {
                     "maxlv": 54,
-                    "minlv": 53,
+                    "minlv": 54,
                     "monsNo": 301
                 },
                 {
@@ -56732,8 +56762,8 @@
                     "monsNo": 65562
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 864
                 }
             ],
@@ -56749,8 +56779,8 @@
                     "monsNo": 65562
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 864
                 }
             ],
@@ -56766,8 +56796,8 @@
                     "monsNo": 65562
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 864
                 }
             ],
@@ -56783,8 +56813,8 @@
                     "monsNo": 65562
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 864
                 }
             ],
@@ -56800,36 +56830,36 @@
                     "monsNo": 65562
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 864
                 }
             ],
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 45,
-                    "minlv": 35,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 72
                 },
                 {
-                    "maxlv": 45,
-                    "minlv": 35,
+                    "maxlv": 55,
+                    "minlv": 55,
                     "monsNo": 278
                 },
                 {
                     "maxlv": 55,
-                    "minlv": 45,
+                    "minlv": 55,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 55,
-                    "minlv": 45,
+                    "minlv": 55,
                     "monsNo": 279
                 },
                 {
                     "maxlv": 55,
-                    "minlv": 45,
+                    "minlv": 55,
                     "monsNo": 279
                 }
             ],
@@ -56940,7 +56970,7 @@
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 44
+                    "monsNo": 441
                 },
                 {
                     "maxlv": 59,
@@ -56987,7 +57017,7 @@
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 13
+                    "monsNo": 70
                 },
                 {
                     "maxlv": 59,
@@ -57022,18 +57052,18 @@
             "swayGrass": [
                 {
                     "maxlv": 59,
-                    "minlv": 58,
-                    "monsNo": 315
-                },
-                {
-                    "maxlv": 59,
-                    "minlv": 58,
-                    "monsNo": 65959
+                    "minlv": 59,
+                    "monsNo": 178
                 },
                 {
                     "maxlv": 59,
                     "minlv": 59,
-                    "monsNo": 213
+                    "monsNo": 178
+                },
+                {
+                    "maxlv": 59,
+                    "minlv": 59,
+                    "monsNo": 178
                 },
                 {
                     "maxlv": 59,
@@ -57065,8 +57095,8 @@
                     "monsNo": 65637
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -57082,8 +57112,8 @@
                     "monsNo": 65637
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -57099,8 +57129,8 @@
                     "monsNo": 65637
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -57116,8 +57146,8 @@
                     "monsNo": 65637
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -57133,8 +57163,8 @@
                     "monsNo": 65637
                 },
                 {
-                    "maxlv": 59,
-                    "minlv": 59,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 131152
                 }
             ],
@@ -57142,27 +57172,27 @@
             "water_mons": [
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 279
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 65959
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 65959
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 65959
                 }
             ],
@@ -57257,32 +57287,32 @@
             "ground_mons": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 22
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 67
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 20
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 57
                 },
                 {
@@ -57302,7 +57332,7 @@
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 326
                 },
                 {
@@ -57319,54 +57349,54 @@
             "tairyo": [
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 75
                 }
             ],
             "day": [
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 75
                 }
             ],
             "night": [
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 75
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 75
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
-                    "monsNo": 20
-                },
-                {
-                    "maxlv": 67,
-                    "minlv": 66,
-                    "monsNo": 57
+                    "minlv": 67,
+                    "monsNo": 326
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 297
+                    "monsNo": 326
+                },
+                {
+                    "maxlv": 67,
+                    "minlv": 67,
+                    "monsNo": 326
                 },
                 {
                     "maxlv": 67,
@@ -57398,8 +57428,8 @@
                     "monsNo": 65589
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 864
                 }
             ],
@@ -57415,8 +57445,8 @@
                     "monsNo": 65589
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 864
                 }
             ],
@@ -57432,8 +57462,8 @@
                     "monsNo": 65589
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 864
                 }
             ],
@@ -57449,8 +57479,8 @@
                     "monsNo": 65589
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 864
                 }
             ],
@@ -57466,8 +57496,8 @@
                     "monsNo": 65589
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 864
                 }
             ],
@@ -57475,27 +57505,27 @@
             "water_mons": [
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 61
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 55
                 }
             ],
@@ -57558,28 +57588,28 @@
             "encRate_sugoi": 100,
             "sugoi_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 }
             ]
@@ -57600,27 +57630,27 @@
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 227
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 207
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 327
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 324
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 110
                 },
                 {
@@ -57635,7 +57665,7 @@
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 207
                 },
                 {
@@ -57652,54 +57682,54 @@
             "tairyo": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 227
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 207
                 }
             ],
             "day": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 227
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 207
                 }
             ],
             "night": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 227
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 207
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
-                    "monsNo": 327
-                },
-                {
-                    "maxlv": 67,
-                    "minlv": 66,
-                    "monsNo": 324
+                    "minlv": 67,
+                    "monsNo": 207
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 227
+                    "monsNo": 207
+                },
+                {
+                    "maxlv": 67,
+                    "minlv": 67,
+                    "monsNo": 207
                 },
                 {
                     "maxlv": 67,
@@ -57731,8 +57761,8 @@
                     "monsNo": 863
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 65735
                 }
             ],
@@ -57748,8 +57778,8 @@
                     "monsNo": 863
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 65735
                 }
             ],
@@ -57765,8 +57795,8 @@
                     "monsNo": 863
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 65735
                 }
             ],
@@ -57782,8 +57812,8 @@
                     "monsNo": 863
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 65735
                 }
             ],
@@ -57799,8 +57829,8 @@
                     "monsNo": 863
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 65735
                 }
             ],
@@ -57808,27 +57838,27 @@
             "water_mons": [
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 61
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 61
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 61
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 61
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 61
                 }
             ],
@@ -57891,28 +57921,28 @@
             "encRate_sugoi": 100,
             "sugoi_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 }
             ]
@@ -57923,17 +57953,17 @@
             "ground_mons": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 332
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 228
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 51
                 },
                 {
@@ -57943,7 +57973,7 @@
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 329
                 },
                 {
@@ -57953,22 +57983,22 @@
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 375
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 444
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 450
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 450
                 },
                 {
@@ -57985,7 +58015,7 @@
             "tairyo": [
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 51
                 },
                 {
@@ -57997,7 +58027,7 @@
             "day": [
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 51
                 },
                 {
@@ -58009,7 +58039,7 @@
             "night": [
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 51
                 },
                 {
@@ -58021,13 +58051,13 @@
             "swayGrass": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
-                    "monsNo": 329
+                    "minlv": 67,
+                    "monsNo": 450
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
-                    "monsNo": 344
+                    "minlv": 67,
+                    "monsNo": 450
                 },
                 {
                     "maxlv": 67,
@@ -58064,8 +58094,8 @@
                     "monsNo": 65587
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 864
                 }
             ],
@@ -58081,8 +58111,8 @@
                     "monsNo": 65587
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 864
                 }
             ],
@@ -58098,9 +58128,9 @@
                     "monsNo": 65587
                 },
                 {
-                    "maxlv": 0,
-                    "minlv": 0,
-                    "monsNo": 0
+                    "maxlv": 67,
+                    "minlv": 67,
+                    "monsNo": 864
                 }
             ],
             "gbaFire": [
@@ -58115,8 +58145,8 @@
                     "monsNo": 65587
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 864
                 }
             ],
@@ -58132,8 +58162,8 @@
                     "monsNo": 65587
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 864
                 }
             ],
@@ -58141,27 +58171,27 @@
             "water_mons": [
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 61
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 61
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 61
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 61
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 61
                 }
             ],
@@ -58224,28 +58254,28 @@
             "encRate_sugoi": 100,
             "sugoi_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 340
                 }
             ]
@@ -58256,17 +58286,17 @@
             "ground_mons": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 123
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 127
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 166
                 },
                 {
@@ -58281,7 +58311,7 @@
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 315
                 },
                 {
@@ -58291,17 +58321,17 @@
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 70
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 314
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 313
                 },
                 {
@@ -58318,7 +58348,7 @@
             "tairyo": [
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 166
                 },
                 {
@@ -58330,7 +58360,7 @@
             "day": [
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 191
                 },
                 {
@@ -58342,7 +58372,7 @@
             "night": [
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 168
                 },
                 {
@@ -58354,18 +58384,18 @@
             "swayGrass": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
-                    "monsNo": 49
-                },
-                {
-                    "maxlv": 67,
-                    "minlv": 66,
-                    "monsNo": 315
+                    "minlv": 67,
+                    "monsNo": 313
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 314
+                    "monsNo": 313
+                },
+                {
+                    "maxlv": 67,
+                    "minlv": 67,
+                    "monsNo": 313
                 },
                 {
                     "maxlv": 67,
@@ -58397,8 +58427,8 @@
                     "monsNo": 65639
                 },
                 {
-                    "maxlv": 60,
-                    "minlv": 50,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 131152
                 }
             ],
@@ -58414,8 +58444,8 @@
                     "monsNo": 65639
                 },
                 {
-                    "maxlv": 60,
-                    "minlv": 50,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 131152
                 }
             ],
@@ -58431,8 +58461,8 @@
                     "monsNo": 65639
                 },
                 {
-                    "maxlv": 60,
-                    "minlv": 50,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 131152
                 }
             ],
@@ -58448,8 +58478,8 @@
                     "monsNo": 65639
                 },
                 {
-                    "maxlv": 60,
-                    "minlv": 50,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 131152
                 }
             ],
@@ -58465,8 +58495,8 @@
                     "monsNo": 65639
                 },
                 {
-                    "maxlv": 60,
-                    "minlv": 50,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 131152
                 }
             ],
@@ -58474,27 +58504,27 @@
             "water_mons": [
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 284
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 284
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 284
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 284
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 284
                 }
             ],
@@ -58557,28 +58587,28 @@
             "encRate_sugoi": 100,
             "sugoi_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 119
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 119
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 119
                 }
             ]
@@ -58730,7 +58760,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -58747,7 +58777,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -58764,7 +58794,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -58781,7 +58811,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -58798,7 +58828,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65747
                 }
@@ -58807,27 +58837,27 @@
             "water_mons": [
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 54
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 54
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 30,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 30,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 30,
+                    "minlv": 40,
                     "monsNo": 55
                 }
             ],
@@ -59063,7 +59093,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -59080,7 +59110,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -59097,7 +59127,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -59114,7 +59144,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -59131,7 +59161,7 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 20,
+                    "maxlv": 40,
                     "minlv": 40,
                     "monsNo": 65758
                 }
@@ -59139,28 +59169,28 @@
             "encRate_wat": 10,
             "water_mons": [
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
-                    "monsNo": 54
-                },
-                {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 54
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
+                    "monsNo": 54
+                },
+                {
+                    "maxlv": 40,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 55
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 55
                 }
             ],
@@ -59397,7 +59427,7 @@
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 904
                 }
             ],
@@ -59414,7 +59444,7 @@
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 904
                 }
             ],
@@ -59431,7 +59461,7 @@
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 904
                 }
             ],
@@ -59448,7 +59478,7 @@
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 904
                 }
             ],
@@ -59465,7 +59495,7 @@
                 },
                 {
                     "maxlv": 40,
-                    "minlv": 20,
+                    "minlv": 40,
                     "monsNo": 904
                 }
             ],
@@ -59589,12 +59619,12 @@
                 {
                     "maxlv": 0,
                     "minlv": 0,
-                    "monsNo": 279
+                    "monsNo": 0
                 },
                 {
                     "maxlv": 0,
                     "minlv": 0,
-                    "monsNo": 419
+                    "monsNo": 0
                 },
                 {
                     "maxlv": 0,
@@ -59729,8 +59759,8 @@
                     "monsNo": 862
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
@@ -59746,8 +59776,8 @@
                     "monsNo": 862
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
@@ -59763,8 +59793,8 @@
                     "monsNo": 862
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
@@ -59780,8 +59810,8 @@
                     "monsNo": 862
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
@@ -59797,36 +59827,36 @@
                     "monsNo": 862
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 40,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 131152
                 }
             ],
             "encRate_wat": 20,
             "water_mons": [
                 {
-                    "maxlv": 40,
-                    "minlv": 30,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 278
                 },
                 {
-                    "maxlv": 30,
-                    "minlv": 20,
+                    "maxlv": 45,
+                    "minlv": 45,
                     "monsNo": 458
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 279
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 226
                 },
                 {
                     "maxlv": 45,
-                    "minlv": 35,
+                    "minlv": 45,
                     "monsNo": 226
                 }
             ],
@@ -60062,8 +60092,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -60079,8 +60109,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -60096,8 +60126,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -60113,8 +60143,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -60130,8 +60160,8 @@
                     "monsNo": 0
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 60,
+                    "minlv": 60,
                     "monsNo": 864
                 }
             ],
@@ -60139,27 +60169,27 @@
             "water_mons": [
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 279
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 226
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 226
                 },
                 {
                     "maxlv": 60,
-                    "minlv": 50,
+                    "minlv": 60,
                     "monsNo": 226
                 }
             ],
@@ -60254,22 +60284,22 @@
             "ground_mons": [
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 22
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 20
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 24
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 28
                 },
                 {
@@ -60284,7 +60314,7 @@
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 99
                 },
                 {
@@ -60316,54 +60346,54 @@
             "tairyo": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 24
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 28
                 }
             ],
             "day": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 24
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 28
                 }
             ],
             "night": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 24
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 28
                 }
             ],
             "swayGrass": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
-                    "monsNo": 78
-                },
-                {
-                    "maxlv": 67,
-                    "minlv": 66,
-                    "monsNo": 85
+                    "minlv": 67,
+                    "monsNo": 28
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 24
+                    "monsNo": 28
+                },
+                {
+                    "maxlv": 67,
+                    "minlv": 67,
+                    "monsNo": 28
                 },
                 {
                     "maxlv": 67,
@@ -60395,8 +60425,8 @@
                     "monsNo": 65614
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 904
                 }
             ],
@@ -60412,8 +60442,8 @@
                     "monsNo": 65614
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 904
                 }
             ],
@@ -60429,8 +60459,8 @@
                     "monsNo": 65614
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 904
                 }
             ],
@@ -60446,8 +60476,8 @@
                     "monsNo": 65614
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 904
                 }
             ],
@@ -60463,8 +60493,8 @@
                     "monsNo": 65614
                 },
                 {
-                    "maxlv": 40,
-                    "minlv": 20,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 904
                 }
             ],
@@ -60472,27 +60502,27 @@
             "water_mons": [
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 278
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 279
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 73
                 }
             ],
@@ -60555,28 +60585,28 @@
             "encRate_sugoi": 100,
             "sugoi_mons": [
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 117
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 369
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 369
                 },
                 {
-                    "maxlv": 50,
-                    "minlv": 50,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 369
                 }
             ]
@@ -60587,17 +60617,17 @@
             "ground_mons": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 279
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 419
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 65959
                 },
                 {
@@ -60607,12 +60637,12 @@
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 336
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 335
                 },
                 {
@@ -60622,12 +60652,12 @@
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 176
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 357
                 },
                 {
@@ -60637,7 +60667,7 @@
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 357
                 },
                 {
@@ -60649,7 +60679,7 @@
             "tairyo": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 65959
                 },
                 {
@@ -60661,7 +60691,7 @@
             "day": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 65959
                 },
                 {
@@ -60673,7 +60703,7 @@
             "night": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
+                    "minlv": 67,
                     "monsNo": 65959
                 },
                 {
@@ -60685,13 +60715,13 @@
             "swayGrass": [
                 {
                     "maxlv": 67,
-                    "minlv": 66,
-                    "monsNo": 336
+                    "minlv": 67,
+                    "monsNo": 235
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 66,
-                    "monsNo": 335
+                    "minlv": 67,
+                    "monsNo": 235
                 },
                 {
                     "maxlv": 67,
@@ -60720,16 +60750,16 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 65735
                 }
             ],
@@ -60737,16 +60767,16 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 65735
                 }
             ],
@@ -60754,16 +60784,16 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 65735
                 }
             ],
@@ -60771,16 +60801,16 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 65735
                 }
             ],
@@ -60788,16 +60818,16 @@
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66398
+                    "monsNo": 862
                 },
                 {
                     "maxlv": 67,
                     "minlv": 67,
-                    "monsNo": 66399
+                    "monsNo": 862
                 },
                 {
-                    "maxlv": 51,
-                    "minlv": 51,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 65735
                 }
             ],
@@ -60805,27 +60835,27 @@
             "water_mons": [
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 364
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 73
                 },
                 {
                     "maxlv": 67,
-                    "minlv": 65,
+                    "minlv": 67,
                     "monsNo": 73
                 }
             ],
@@ -60888,28 +60918,28 @@
             "encRate_sugoi": 100,
             "sugoi_mons": [
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 130
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 222
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 321
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 321
                 },
                 {
-                    "maxlv": 65,
-                    "minlv": 65,
+                    "maxlv": 67,
+                    "minlv": 67,
                     "monsNo": 321
                 }
             ]


### PR DESCRIPTION
-All radar mons in all routes have been homogenized into one Radar mon, no changes noticeable to the player except for the following: -Valley Windworks: Only Plusle shows up via Pokeradar -Route 205 South: Only Minun shows up via Pokeradar -Eterna Forest: Only Wurmples shows up via Pokeradar -Route 212 South: Only Muk shows up via Pokeradar
-Trophy Garden: When Incense and Radar are both active, (and the Mon of the day for today and yesterday with Mr Backlot is NOT Eevee but other species) Eevee/Porgyon can still be found in day and morning slots, Cleffa at night slots

-all wild encounters have had their levels properly homogenized to be the highest for their route/slot type, fixing some bugged inverted minmax caps in the process -fixed a bug with no incense mon being called for surfing in the Feebas pools in mt coronet, it should now be Galarian Slowpoke encountered via surfing with incense -Mt Coronet 4th floor's fishing rod encounters had only 3 of their 5 slots in their tables, added the missing tables and properly set the missing mons to Dratini and Dragonair -Internally fixed the formatting of certain routes just for cleanliness, no actual changes to species or percents or anything, just making sure everything is in its proper place/slots -Ingame has Achieved full parity with Renegade Platinum docs, fixed various typos/wrong species in just one slot in certain routes a Nidoking was meant to be Nidorino in r221
a Golem was meant to be Graveller in Victory Road 2F a Weedle was meant to be Weepinbell in r224
a Chingling was meant to be Chatot in r213
A Shinx was meant to be a Luxio in r222
a Marill was meant to be Parasect in Great Marsh 3/4 an Ursaring was meant to be Swalot in Great Marsh 5/6